### PR TITLE
Do not rely on Dynamic Media feature flag to detect DM capability on publish instances

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,12 +23,22 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.14.12" date="not released">
+      <action type="update" dev="sseifert">
+        Dynamic Media Support: Do not rely on Dynamic Media feature flag to detect DM capability on publish instances. In "AUTO" mode only the availability of DM metadata on a given asset is checked.
+      </action>
+    </release>
+
     <release version="1.14.10" date="2022-09-27">
-      <action type="update" dev="sseifert">Dynamic Media Support: Introduce OSGi configuration parameter dmCapabilityDetection to switch from auto-detection to enable or disable Dynamic Media capability via configuration.</action>
+      <action type="update" dev="sseifert">
+        Dynamic Media Support: Introduce OSGi configuration parameter dmCapabilityDetection to switch from auto-detection to enable or disable Dynamic Media capability via configuration.
+      </action>
     </release>
 
     <release version="1.14.8" date="2022-09-20">
-      <action type="fix" dev="sseifert">Dynamic Media Support: Make use of smart-cropped image rendition also in the case if the original image has same ratio as the requested ratio.</action>
+      <action type="fix" dev="sseifert">
+        Dynamic Media Support: Make use of smart-cropped image rendition also in the case if the original image has same ratio as the requested ratio.
+      </action>
     </release>
 
     <release version="1.14.6" date="2022-09-02">

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
@@ -94,7 +94,8 @@ public final class DamContext implements Adaptable {
    * @return Whether dynamic media is enabled on this AEM instance
    */
   public boolean isDynamicMediaEnabled() {
-    return dynamicMediaSupportService.isDynamicMediaEnabled();
+    return dynamicMediaSupportService.isDynamicMediaEnabled()
+        && dynamicMediaSupportService.isDynamicMediaCapabilityEnabled(isDynamicMediaAsset());
   }
 
   /**

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaCapabilityDetection.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaCapabilityDetection.java
@@ -20,23 +20,26 @@
 package io.wcm.handler.mediasource.dam.impl.dynamicmedia;
 
 /**
- * Modes to detect if Dynamic Media capability is available on a author/publish instance.
+ * Modes to detect if Dynamic Media is available for a given asset.
  */
 enum DynamicMediaCapabilityDetection {
 
   /**
-   * Default: Auto-detect if Dynamic Media capability is available on author/publish instance by
-   * checking for the feature flag com.adobe.dam.asset.scene7.feature.flag.
+   * Default: Auto-detect if Dynamic Media is available for a given asset.
+   * If a property <code>dam:scene7File</code> exists in the metadata of the asset, Dynamic Media is considered
+   * available. If the property does not exist, the asset is treated as non-DM asset and renditions
+   * are rendered within AEM.
    */
   AUTO,
 
   /**
-   * Assume Dynamic Media capability is not available without doing any auto-detection.
+   * Disables the detection of Dynamic Media. Dynamic Media is never used.
+   * All renditions are rendered within AEM.
    */
   OFF,
 
   /**
-   * Assume Dynamic Media capability is available without doing any auto-detection.
+   * Configures that Dynamic Media is available for the environment and should be used for all assets.
    */
   ON
 

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportService.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportService.java
@@ -40,6 +40,12 @@ public interface DynamicMediaSupportService {
   boolean isDynamicMediaEnabled();
 
   /**
+   * @param isDynamicMediaAsset true if given asset has DM metadata properties available.
+   * @return Whether dynamic media capability is enabled for the given asset
+   */
+  boolean isDynamicMediaCapabilityEnabled(boolean isDynamicMediaAsset);
+
+  /**
    * @return Whether a transparent fallback to Media Handler-based rendering of renditions is allowed
    *         if the appropriate Dynamic Media metadata is not preset for an asset.
    */

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportServiceImpl.java
@@ -31,7 +31,6 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.featureflags.Features;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Activate;
@@ -103,13 +102,6 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
 
   }
 
-  /**
-   * Feature flag signaling activation of DM on AEM instance.
-   */
-  public static final String ASSETS_SCENE7_FEATURE_FLAG_PID = "com.adobe.dam.asset.scene7.feature.flag";
-
-  @Reference
-  private Features featureFlagService;
   @Reference
   private PublishUtils dynamicMediaPublishUtils;
   @Reference
@@ -134,23 +126,24 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
     this.disableAemFallback = config.disableAemFallback();
     this.imageSizeLimit = new Dimension(config.imageSizeLimitWidth(), config.imageSizeLimitHeight());
 
-    if (this.enabled && log.isInfoEnabled()) {
+    if (this.enabled) {
       log.info("DynamicMediaSupport: enabled={}, capabilityEnabled={}, capabilityDetection={}, "
           + "authorPreviewMode={}, disableAemFallback={}, imageSizeLimit={}",
-          isDynamicMediaEnabled(), isDynamicMediaCapabilityEnabled(), this.dmCapabilityDetection,
+          this.enabled, this.dmCapabilityDetection, this.dmCapabilityDetection,
           this.authorPreviewMode, this.disableAemFallback, this.imageSizeLimit);
     }
   }
 
   @Override
   public boolean isDynamicMediaEnabled() {
-    return this.enabled && isDynamicMediaCapabilityEnabled();
+    return this.enabled;
   }
 
-  private boolean isDynamicMediaCapabilityEnabled() {
+  @Override
+  public boolean isDynamicMediaCapabilityEnabled(boolean isDynamicMediaAsset) {
     switch (dmCapabilityDetection) {
       case AUTO:
-        return featureFlagService.isEnabled(ASSETS_SCENE7_FEATURE_FLAG_PID);
+        return isDynamicMediaAsset;
       case ON:
         return true;
       case OFF:

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndDynamicMediaNoFallbackTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndDynamicMediaNoFallbackTest.java
@@ -19,11 +19,9 @@
  */
 package io.wcm.handler.media.impl;
 
-import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.DynamicMediaSupportServiceImpl.ASSETS_SCENE7_FEATURE_FLAG_PID;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.sling.featureflags.impl.ConfiguredFeature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,15 +44,18 @@ import io.wcm.wcm.commons.contenttype.ContentType;
 class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaNoFallbackTest extends MediaHandlerImplImageFileTypesEnd2EndTest {
 
   @Override
+  boolean isCreateAssetWithDynamicMediaMetadata() {
+    // enable dynamic media metadata in asset
+    return true;
+  }
+
+  @Override
   @BeforeEach
   void setUp() {
-    // activate dynamic media
-    context.registerInjectActivateService(new ConfiguredFeature(),
-        "name", ASSETS_SCENE7_FEATURE_FLAG_PID,
-        "enabled", true);
-    // disable AEM fallback
+    // explicitly activate DM capability, disable AEM fallback,
     context.registerInjectActivateService(new DynamicMediaSupportServiceImpl(),
         Constants.SERVICE_RANKING, 100,
+        "dmCapabilityDetection", "ON",
         "disableAemFallback", true);
     super.setUp();
   }

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest.java
@@ -19,10 +19,6 @@
  */
 package io.wcm.handler.media.impl;
 
-import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.DynamicMediaSupportServiceImpl.ASSETS_SCENE7_FEATURE_FLAG_PID;
-
-import org.apache.sling.featureflags.impl.ConfiguredFeature;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -43,13 +39,9 @@ import io.wcm.wcm.commons.contenttype.ContentType;
 class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandlerImplImageFileTypesEnd2EndTest {
 
   @Override
-  @BeforeEach
-  void setUp() {
-    // activate dynamic media
-    context.registerInjectActivateService(new ConfiguredFeature(),
-        "name", ASSETS_SCENE7_FEATURE_FLAG_PID,
-        "enabled", true);
-    super.setUp();
+  boolean isCreateAssetWithDynamicMediaMetadata() {
+    // enable dynamic media metadata in asset
+    return true;
   }
 
   @Override

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
@@ -33,6 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.osgi.MapUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,6 +82,10 @@ class MediaHandlerImplImageFileTypesEnd2EndTest {
 
     imageFileServlet = context.registerInjectActivateService(new ImageFileServlet());
     mediaHandler = AdaptTo.notNull(context.request(), MediaHandler.class);
+  }
+
+  boolean isCreateAssetWithDynamicMediaMetadata() {
+    return false;
   }
 
   @Test
@@ -377,8 +384,14 @@ class MediaHandlerImplImageFileTypesEnd2EndTest {
   Asset createSampleAsset(String classpathResource, String contentType) {
     String fileName = FilenameUtils.getName(classpathResource);
     String fileExtension = FilenameUtils.getExtension(classpathResource);
-    Asset asset = context.create().asset("/content/dam/" + fileName, classpathResource, contentType,
-        Scene7Constants.PN_S7_FILE, "DummyFolder/" + fileName);
+    Map<String, Object> metadata;
+    if (isCreateAssetWithDynamicMediaMetadata()) {
+      metadata = MapUtil.toMap(Scene7Constants.PN_S7_FILE, "DummyFolder/" + fileName);
+    }
+    else {
+      metadata = Collections.emptyMap();
+    }
+    Asset asset = context.create().asset("/content/dam/" + fileName, classpathResource, contentType, metadata);
     context.create().assetRendition(asset, "cq5dam.web.sample." + fileExtension, classpathResource, contentType);
     return asset;
   }


### PR DESCRIPTION
Dynamic Media Support: Do not rely on Dynamic Media feature flag to detect DM capability on publish instances.
In "AUTO" mode only the availability of DM metadata on a given asset is checked.