### PR TITLE
Dynamic Media: Ensure smart-cropped rendition fulfills minimum size

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.14.14" date="not released">
+      <action type="fix" dev="sseifert">
+        Dynamic Media Support: Ensure smart-cropped renditions fulfill minimum size requirements.
+      </action>
+    </release>
+
     <release version="1.14.12" date="2022-10-10">
       <action type="update" dev="sseifert">
         Dynamic Media Support: Do not rely on Dynamic Media feature flag to detect DM capability on publish instances. In "AUTO" mode only the availability of DM metadata on a given asset is checked.

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
@@ -23,7 +23,10 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.adapter.Adaptable;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -159,6 +162,21 @@ public final class DamContext implements Adaptable {
     }
     else {
       return imageProfile;
+    }
+  }
+
+  /**
+   * @return Resource resolver from current context
+   */
+  public @NotNull ResourceResolver getResourceResolver() {
+    if (adaptable instanceof Resource) {
+      return ((Resource)adaptable).getResourceResolver();
+    }
+    else if (adaptable instanceof SlingHttpServletRequest) {
+      return ((SlingHttpServletRequest)adaptable).getResourceResolver();
+    }
+    else {
+      throw new IllegalStateException("Adaptable is neither Resoucre nor SlingHttpServletRequest");
     }
   }
 

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamRendition.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamRendition.java
@@ -103,12 +103,9 @@ class DamRendition extends SlingAdaptable implements Rendition {
       }
     }
 
-    // if DM with smart cropping is used: ensure the chosen area of image is large enough to fill the requested size
-    if (damContext.isDynamicMediaEnabled()) {
-      if (log.isTraceEnabled()) {
-        log.trace("DamRendition: resolvedRendition={}, mediaArgs={}, cropDimension={}, rotation={}",
-            resolvedRendition, mediaArgs, cropDimension, rotation);
-      }
+    if (log.isTraceEnabled()) {
+      log.trace("DamRendition: resolvedRendition={}, mediaArgs={}, cropDimension={}, rotation={}",
+          resolvedRendition, mediaArgs, cropDimension, rotation);
     }
 
     this.rendition = resolvedRendition;

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamRendition.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamRendition.java
@@ -27,6 +27,7 @@ import org.apache.sling.api.adapter.SlingAdaptable;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,43 +114,53 @@ class DamRendition extends SlingAdaptable implements Rendition {
 
   @Override
   public String getUrl() {
-    if (this.rendition == null) {
+    if (rendition == null) {
       return null;
     }
     String url = null;
-    boolean dynamicMediaEnabled = damContext.isDynamicMediaEnabled();
-    if (dynamicMediaEnabled) {
+    if (damContext.isDynamicMediaEnabled()) {
       if (damContext.isDynamicMediaAsset()) {
-        // if DM is enabled: try to get rendition URL from dynamic media
-        String dynamicMediaPath = this.rendition.getDynamicMediaPath(this.mediaArgs.isContentDispositionAttachment(), damContext);
-        String productionAssetUrl = damContext.getDynamicMediaServerUrl();
-        if (dynamicMediaPath != null && productionAssetUrl != null) {
-          url = productionAssetUrl + dynamicMediaPath;
-        }
+        url = buildDynamicMediaUrl();
         if (url == null) {
-          // asset is valid DM asset, but rendition (probably smart-cropped) it too small for the requested size
+          // asset is valid DM asset, but no valid rendition could be generated
+          // reason might be that the smart-cropped rendition was too small for the requested size
           return null;
         }
       }
       else {
         // DM is enabled, but given asset is not a DM asset
         if (damContext.isDynamicMediaAemFallbackDisabled()) {
-          log.warn("Asset is not a valid DM asset, fallback disabled, rendition invalid: {}", this.rendition.getRendition().getPath());
+          log.warn("Asset is not a valid DM asset, fallback disabled, rendition invalid: {}", rendition.getRendition().getPath());
           return null;
         }
         else {
-          log.trace("Asset is not a valid DM asset, fallback to AEM-rendered rendition: {}", this.rendition.getRendition().getPath());
+          log.trace("Asset is not a valid DM asset, fallback to AEM-rendered rendition: {}", rendition.getRendition().getPath());
         }
       }
     }
     if (url == null) {
       // Render renditions in AEM: build externalized URL
       UrlHandler urlHandler = AdaptTo.notNull(damContext, UrlHandler.class);
-      String mediaPath = this.rendition.getMediaPath(this.mediaArgs.isContentDispositionAttachment());
-      url = urlHandler.get(mediaPath).urlMode(this.mediaArgs.getUrlMode())
-          .buildExternalResourceUrl(this.rendition.adaptTo(Resource.class));
+      String mediaPath = rendition.getMediaPath(mediaArgs.isContentDispositionAttachment());
+      url = urlHandler.get(mediaPath).urlMode(mediaArgs.getUrlMode())
+          .buildExternalResourceUrl(rendition.adaptTo(Resource.class));
     }
     return url;
+  }
+
+  /**
+   * Build DM URL for this rendition based on the calculated DM path and the configured DM hostname.
+   * @return DM URL or null if either DM path or configured DM hostname is null
+   */
+  private @Nullable String buildDynamicMediaUrl() {
+    String dynamicMediaPath = rendition.getDynamicMediaPath(mediaArgs.isContentDispositionAttachment(), damContext);
+    String productionAssetUrl = damContext.getDynamicMediaServerUrl();
+    if (dynamicMediaPath != null && productionAssetUrl != null) {
+      return productionAssetUrl + dynamicMediaPath;
+    }
+    else {
+      return null;
+    }
   }
 
   @Override

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadata.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadata.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.sling.api.adapter.SlingAdaptable;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.day.cq.dam.api.Rendition;
 import com.day.image.Layer;
@@ -196,7 +197,7 @@ class RenditionMetadata extends SlingAdaptable implements Comparable<RenditionMe
    * @param damContext DAM context
    * @return Dynamic media path part or null if dynamic media not supported for this rendition
    */
-  public @NotNull String getDynamicMediaPath(boolean contentDispositionAttachment, DamContext damContext) {
+  public @Nullable String getDynamicMediaPath(boolean contentDispositionAttachment, DamContext damContext) {
     if (contentDispositionAttachment) {
       // serve static content from dynamic media for content disposition attachment
       return DynamicMediaPath.buildContent(damContext, true);

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/VirtualRenditionMetadata.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/VirtualRenditionMetadata.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.day.cq.dam.api.Rendition;
 import com.day.image.Layer;
@@ -88,7 +89,7 @@ class VirtualRenditionMetadata extends RenditionMetadata {
   }
 
   @Override
-  public @NotNull String getDynamicMediaPath(boolean contentDispositionAttachment, DamContext damContext) {
+  public @Nullable String getDynamicMediaPath(boolean contentDispositionAttachment, DamContext damContext) {
     if (contentDispositionAttachment) {
       // serve static content from dynamic media for content disposition attachment
       return DynamicMediaPath.buildContent(damContext, true);

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/VirtualTransformedRenditionMetadata.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/VirtualTransformedRenditionMetadata.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.day.cq.dam.api.Rendition;
 import com.day.image.Layer;
@@ -93,7 +94,7 @@ class VirtualTransformedRenditionMetadata extends RenditionMetadata {
   }
 
   @Override
-  public @NotNull String getDynamicMediaPath(boolean contentDispositionAttachment, DamContext damContext) {
+  public @Nullable String getDynamicMediaPath(boolean contentDispositionAttachment, DamContext damContext) {
     // render virtual rendition with dynamic media (we ignore contentDispositionAttachment here)
     return DynamicMediaPath.buildImage(damContext, getWidth(), getHeight(), this.cropDimension, this.rotation);
   }

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaPath.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaPath.java
@@ -116,11 +116,11 @@ public final class DynamicMediaPath {
     // check for smart cropping when no cropping was applied by default, or auto-crop is enabled
     if (SmartCrop.canApply(cropDimension, rotation)) {
       // check for matching image profile and use predefined cropping preset if match found
-      NamedDimension smartCropDef = SmartCrop.getDimension(damContext, width, height);
+      NamedDimension smartCropDef = SmartCrop.getDimension(damContext.getImageProfile(), width, height);
       if (smartCropDef != null) {
-        if (!SmartCrop.isMatchingSize(damContext, smartCropDef, width, height)) {
+        if (!SmartCrop.isMatchingSize(damContext.getAsset(), damContext.getResourceResolver(), smartCropDef, width, height)) {
           // smart crop should be applied, but selected area is too small, treat as invalid
-          logResult(damContext, "<too small>");
+          logResult(damContext, "<too small for " + width + "x" + height + ">");
           return null;
         }
         result.append("%3A").append(smartCropDef.getName()).append("?")

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/ImageProfileImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/ImageProfileImpl.java
@@ -30,11 +30,22 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Wraps access to dynamic media image profile.
  */
-final class ImageProfileImpl implements ImageProfile {
+public final class ImageProfileImpl implements ImageProfile {
 
-  static final String PN_CROP_TYPE = "crop_type";
-  static final String CROP_TYPE_SMART = "crop_smart";
-  static final String PN_BANNER = "banner";
+  /**
+   * Crop type
+   */
+  public static final String PN_CROP_TYPE = "crop_type";
+
+  /**
+   * Smart cropping crop type.
+   */
+  public static final String CROP_TYPE_SMART = "crop_smart";
+
+  /**
+   * Banner property with string like: Crop-1,100,60|Crop-2,50,30
+   */
+  public static final String PN_BANNER = "banner";
 
   private final List<NamedDimension> smartCropDefinitions;
 

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
@@ -75,7 +75,7 @@ public final class SmartCrop {
    * @param imageProfile Image profile from DAM context (null if no is defined)
    * @param width Width
    * @param height Height
-   * @return Smart cropping definition with requested with/height - or null if no match
+   * @return Smart cropping definition with requested width/height - or null if no match
    */
   static @Nullable NamedDimension getDimension(@Nullable ImageProfile imageProfile, long width, long height) {
     if (imageProfile == null) {
@@ -96,11 +96,11 @@ public final class SmartCrop {
 
   /**
    * Verifies that the actual image area picked in smart cropping (either automatic or manual) results in
-   * a renditions size that fulfills at least the requested width/height.
+   * a rendition size that fulfills at least the requested width/height.
    * @param asset DAM asset
    * @param resourceResolver Resource resolve
    * @param smartCropDef Smart cropping dimension
-   * @param width Requested with
+   * @param width Requested width
    * @param height Requested height
    * @return true if size is matching, or no width/height information for the cropped area is available
    */

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
@@ -20,21 +20,22 @@
 package io.wcm.handler.mediasource.dam.impl.dynamicmedia;
 
 import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
+import static com.day.cq.dam.api.DamConstants.RENDITIONS_FOLDER;
 
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.day.cq.dam.api.DamConstants;
+import com.day.cq.dam.api.Asset;
 
 import io.wcm.handler.media.CropDimension;
 import io.wcm.handler.media.Dimension;
 import io.wcm.handler.media.format.Ratio;
 import io.wcm.handler.mediasource.dam.AssetRendition;
-import io.wcm.handler.mediasource.dam.impl.DamContext;
 
 /**
  * Apply Dynamic Media Smart Cropping.
@@ -43,6 +44,9 @@ final class SmartCrop {
 
   private static final double MIN_NORMALIZED_WIDTH_HEIGHT = 0.0001;
   private static final Logger log = LoggerFactory.getLogger(SmartCrop.class);
+
+  static final String PN_NORMALIZED_WIDTH = "normalizedWidth";
+  static final String PN_NORMALIZED_HEIGHT = "normalizedHeight";
 
   private SmartCrop() {
     // static methods only
@@ -61,13 +65,12 @@ final class SmartCrop {
 
   /**
    * Checks DM image profile for a smart cropping definition matching the ratio of the requested width/height.
-   * @param damContext DAM context
+   * @param imageProfile Image profile from DAM context (null if no is defined)
    * @param width Width
    * @param height Height
    * @return Smart cropping definition with requested with/height - or null if no match
    */
-  static @Nullable NamedDimension getDimension(@NotNull DamContext damContext, long width, long height) {
-    ImageProfile imageProfile = damContext.getImageProfile();
+  static @Nullable NamedDimension getDimension(@Nullable ImageProfile imageProfile, long width, long height) {
     if (imageProfile == null) {
       return null;
     }
@@ -87,21 +90,23 @@ final class SmartCrop {
   /**
    * Verifies that the actual image area picked in smart cropping (either automatic or manual) results in
    * a renditions size that fulfills at least the requested width/height.
-   * @param damContext DAM context
+   * @param asset DAM asset
+   * @param resourceResolver Resource resolve
    * @param smartCropDef Smart cropping dimension
    * @param width Requested with
    * @param height Requested height
    * @return true if size is matching, or no width/height information for the cropped area is available
    */
   @SuppressWarnings("java:S1075") // no filesystem paths
-  static boolean isMatchingSize(@NotNull DamContext damContext, @NotNull NamedDimension smartCropDef, long width, long height) {
+  static boolean isMatchingSize(@NotNull Asset asset, @NotNull ResourceResolver resourceResolver,
+      @NotNull NamedDimension smartCropDef, long width, long height) {
     // at this path smart cropping parameters may be stored for each ratio (esp. if manual cropping was applied)
-    String smartCropRenditionPath = damContext.getAsset().getPath()
+    String smartCropRenditionPath = asset.getPath()
         + "/" + JCR_CONTENT
-        + "/" + DamConstants.RENDITIONS_FOLDER
+        + "/" + RENDITIONS_FOLDER
         + "/" + smartCropDef.getName()
         + "/" + JCR_CONTENT;
-    Resource smartCropRendition = damContext.getResourceResolver().getResource(smartCropRenditionPath);
+    Resource smartCropRendition = resourceResolver.getResource(smartCropRenditionPath);
     if (smartCropRendition == null) {
       // if this rendition is not found in repository, we assume the size should be fine
       // on AEMaaCS this path should always exist, in AEMaaCS SDK it seems to be created only when manual cropping
@@ -109,21 +114,22 @@ final class SmartCrop {
       return true;
     }
     ValueMap props = smartCropRendition.getValueMap();
-    double normalizedWidth = props.get("normalizedWidth", 0d);
-    double normalizedHeight = props.get("normalizedHeight", 0d);
-    Dimension originalDimension = AssetRendition.getDimension(damContext.getAsset().getOriginal());
+    double normalizedWidth = props.get(PN_NORMALIZED_WIDTH, 0d);
+    double normalizedHeight = props.get(PN_NORMALIZED_HEIGHT, 0d);
+    Dimension originalDimension = AssetRendition.getDimension(asset.getOriginal());
     if (normalizedWidth < MIN_NORMALIZED_WIDTH_HEIGHT || normalizedHeight < MIN_NORMALIZED_WIDTH_HEIGHT
         || originalDimension == null) {
       // skip further validation if dimensions are not found
       return true;
     }
 
+    // check if smart cropping area is large enough
     long croppedWidth = Math.round(originalDimension.getWidth() * normalizedWidth);
     long croppedHeight = Math.round(originalDimension.getHeight() * normalizedHeight);
     boolean isMatchingSize = (croppedWidth >= width || croppedHeight >= height);
     if (!isMatchingSize) {
       log.debug("Smart cropping area '{}' for asset {} is too small ({} x {}) for requested size {} x {}.",
-          smartCropDef.getName(), damContext.getAsset().getPath(), croppedWidth, croppedHeight, width, height);
+          smartCropDef.getName(), asset.getPath(), croppedWidth, croppedHeight, width, height);
     }
     return isMatchingSize;
   }

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.dam.impl.dynamicmedia;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import io.wcm.handler.media.CropDimension;
+import io.wcm.handler.media.format.Ratio;
+import io.wcm.handler.mediasource.dam.impl.DamContext;
+
+/**
+ * Apply Dynamic Media Smart Cropping.
+ */
+final class SmartCrop {
+
+  private SmartCrop() {
+    // static methods only
+  }
+
+  /**
+   * Smart cropping can be applied when no manual cropping was applied, or auto cropping is enabled.
+   * Additionally, combination with rotation is not allowed.
+   * @param cropDimension Manual crop definition
+   * @param rotation Rotation
+   * @return true if Smart Cropping can be applied
+   */
+  static boolean canApply(@Nullable CropDimension cropDimension, @Nullable Integer rotation) {
+    return (cropDimension == null || cropDimension.isAutoCrop()) && rotation == null;
+  }
+
+  /**
+   * Checks DM image profile for a smart cropping definition matching the ratio of the requested width/height.
+   * @param damContext DAM context
+   * @param width Width
+   * @param height Height
+   * @return Smart cropping definition with requested with/height - or null if no match
+   */
+  static @Nullable NamedDimension getDimension(@NotNull DamContext damContext, long width, long height) {
+    ImageProfile imageProfile = damContext.getImageProfile();
+    if (imageProfile == null) {
+      return null;
+    }
+    Double requestedRatio = Ratio.get(width, height);
+    NamedDimension matchingDimension = imageProfile.getSmartCropDefinitions().stream()
+        .filter(def -> Ratio.matches(Ratio.get(def), requestedRatio))
+        .findFirst().orElse(null);
+    if (matchingDimension != null) {
+      // create new named dimension with actual requested width/height
+      return new NamedDimension(matchingDimension.getName(), width, height);
+    }
+    else {
+      return null;
+    }
+  }
+
+}

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
@@ -19,17 +19,30 @@
  */
 package io.wcm.handler.mediasource.dam.impl.dynamicmedia;
 
+import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.dam.api.DamConstants;
 
 import io.wcm.handler.media.CropDimension;
+import io.wcm.handler.media.Dimension;
 import io.wcm.handler.media.format.Ratio;
+import io.wcm.handler.mediasource.dam.AssetRendition;
 import io.wcm.handler.mediasource.dam.impl.DamContext;
 
 /**
  * Apply Dynamic Media Smart Cropping.
  */
 final class SmartCrop {
+
+  private static final double MIN_NORMALIZED_WIDTH_HEIGHT = 0.0001;
+  private static final Logger log = LoggerFactory.getLogger(SmartCrop.class);
 
   private SmartCrop() {
     // static methods only
@@ -69,6 +82,50 @@ final class SmartCrop {
     else {
       return null;
     }
+  }
+
+  /**
+   * Verifies that the actual image area picked in smart cropping (either automatic or manual) results in
+   * a renditions size that fulfills at least the requested width/height.
+   * @param damContext DAM context
+   * @param smartCropDef Smart cropping dimension
+   * @param width Requested with
+   * @param height Requested height
+   * @return true if size is matching, or no width/height information for the cropped area is available
+   */
+  @SuppressWarnings("java:S1075") // no filesystem paths
+  static boolean isMatchingSize(@NotNull DamContext damContext, @NotNull NamedDimension smartCropDef, long width, long height) {
+    // at this path smart cropping parameters may be stored for each ratio (esp. if manual cropping was applied)
+    String smartCropRenditionPath = damContext.getAsset().getPath()
+        + "/" + JCR_CONTENT
+        + "/" + DamConstants.RENDITIONS_FOLDER
+        + "/" + smartCropDef.getName()
+        + "/" + JCR_CONTENT;
+    Resource smartCropRendition = damContext.getResourceResolver().getResource(smartCropRenditionPath);
+    if (smartCropRendition == null) {
+      // if this rendition is not found in repository, we assume the size should be fine
+      // on AEMaaCS this path should always exist, in AEMaaCS SDK it seems to be created only when manual cropping
+      // is applied in the Assets UI
+      return true;
+    }
+    ValueMap props = smartCropRendition.getValueMap();
+    double normalizedWidth = props.get("normalizedWidth", 0d);
+    double normalizedHeight = props.get("normalizedHeight", 0d);
+    Dimension originalDimension = AssetRendition.getDimension(damContext.getAsset().getOriginal());
+    if (normalizedWidth < MIN_NORMALIZED_WIDTH_HEIGHT || normalizedHeight < MIN_NORMALIZED_WIDTH_HEIGHT
+        || originalDimension == null) {
+      // skip further validation if dimensions are not found
+      return true;
+    }
+
+    long croppedWidth = Math.round(originalDimension.getWidth() * normalizedWidth);
+    long croppedHeight = Math.round(originalDimension.getHeight() * normalizedHeight);
+    boolean isMatchingSize = (croppedWidth >= width || croppedHeight >= height);
+    if (!isMatchingSize) {
+      log.debug("Smart cropping area '{}' for asset {} is too small ({} x {}) for requested size {} x {}.",
+          smartCropDef.getName(), damContext.getAsset().getPath(), croppedWidth, croppedHeight, width, height);
+    }
+    return isMatchingSize;
   }
 
 }

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
@@ -40,13 +40,20 @@ import io.wcm.handler.mediasource.dam.AssetRendition;
 /**
  * Apply Dynamic Media Smart Cropping.
  */
-final class SmartCrop {
+public final class SmartCrop {
+
+  /**
+   * Normalized width (double value 0..1 as percentage of original image).
+   */
+  public static final String PN_NORMALIZED_WIDTH = "normalizedWidth";
+
+  /**
+   * Normalized height (double value 0..1 as percentage of original image).
+   */
+  public static final String PN_NORMALIZED_HEIGHT = "normalizedHeight";
 
   private static final double MIN_NORMALIZED_WIDTH_HEIGHT = 0.0001;
   private static final Logger log = LoggerFactory.getLogger(SmartCrop.class);
-
-  static final String PN_NORMALIZED_WIDTH = "normalizedWidth";
-  static final String PN_NORMALIZED_HEIGHT = "normalizedHeight";
 
   private SmartCrop() {
     // static methods only

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplEnd2EndDynamicMediaSmartCropTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplEnd2EndDynamicMediaSmartCropTest.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.media.impl;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
+import static com.day.cq.dam.api.DamConstants.RENDITIONS_FOLDER;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.CROP_TYPE_SMART;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.PN_BANNER;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.PN_CROP_TYPE;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.PN_NORMALIZED_HEIGHT;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.PN_NORMALIZED_WIDTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.apache.sling.api.resource.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.day.cq.dam.api.Asset;
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.dam.scene7.api.constants.Scene7Constants;
+import com.google.common.collect.ImmutableList;
+
+import io.wcm.handler.media.Media;
+import io.wcm.handler.media.MediaArgs.PictureSource;
+import io.wcm.handler.media.MediaHandler;
+import io.wcm.handler.media.MediaInvalidReason;
+import io.wcm.handler.media.Rendition;
+import io.wcm.handler.media.testcontext.AppAemContext;
+import io.wcm.handler.media.testcontext.DummyMediaFormats;
+import io.wcm.sling.commons.adapter.AdaptTo;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.commons.contenttype.ContentType;
+
+/**
+ * Test media handling with Dynamic Media and Smart Cropping end-2-end.
+ */
+@ExtendWith(AemContextExtension.class)
+class MediaHandlerImplEnd2EndDynamicMediaSmartCropTest {
+
+  private final AemContext context = AppAemContext.newAemContext();
+
+  private Asset asset;
+  private MediaHandler mediaHandler;
+
+  @BeforeEach
+  void setUp() {
+    Resource profile1 = context.create().resource("/conf/global/settings/dam/adminui-extension/imageprofile/profile1",
+        PN_CROP_TYPE, CROP_TYPE_SMART,
+        PN_BANNER, "16-10,16,10|4-3,40,30");
+
+    Resource assetFolder = context.create().resource("/content/dam/folder1");
+    context.create().resource(assetFolder, JCR_CONTENT, DamConstants.IMAGE_PROFILE, profile1.getPath());
+
+    asset = context.create().asset(assetFolder.getPath() + "/test.jpg", 160, 100, ContentType.JPEG,
+        Scene7Constants.PN_S7_FILE, "DummyFolder/test");
+    context.create().assetRenditionWebEnabled(asset, 128, 80); // simulate web rendition that is a bit smaller
+
+    // original asset size is 160x100px
+    // the 4-3 smart crop rendition defines a cropping area of 80x60px
+    String smartCropRenditionPath = asset.getPath() + "/" + JCR_CONTENT + "/" + RENDITIONS_FOLDER
+        + "/4-3/" + JCR_CONTENT;
+    context.create().resource(smartCropRenditionPath,
+        PN_NORMALIZED_WIDTH, 0.5d,
+        PN_NORMALIZED_HEIGHT, 0.6d);
+
+    mediaHandler = AdaptTo.notNull(context.request(), MediaHandler.class);
+  }
+
+  @Test
+  void testValidSmartCroppedRendition() {
+    Media media = getMediaWithWidths(80, 40);
+    assertTrue(media.isValid());
+
+    List<Rendition> renditions = ImmutableList.copyOf(media.getRenditions());
+    assertEquals(2, renditions.size());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=80&hei=60&fit=stretch", renditions.get(0).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=40&hei=30&fit=stretch", renditions.get(1).getUrl());
+  }
+
+  @Test
+  void testInvalidSmartCroppedRendition() {
+    Media media = getMediaWithWidths(100);
+    assertFalse(media.isValid());
+    assertEquals(MediaInvalidReason.NO_MATCHING_RENDITION, media.getMediaInvalidReason());
+  }
+
+  @Test
+  void testSomeInvalidSmartCroppedRendition() {
+    Media media = getMediaWithWidths(100, 80, 40);
+    assertFalse(media.isValid());
+    assertEquals(MediaInvalidReason.NOT_ENOUGH_MATCHING_RENDITIONS, media.getMediaInvalidReason());
+  }
+
+  private Media getMediaWithWidths(long... widths) {
+    return mediaHandler.get(asset.getPath())
+        .pictureSource(new PictureSource(DummyMediaFormats.RATIO2).widths(widths))
+        .autoCrop(true)
+        .build();
+  }
+
+}

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCropTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCropTest.java
@@ -1,0 +1,139 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.dam.impl.dynamicmedia;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
+import static com.day.cq.dam.api.DamConstants.RENDITIONS_FOLDER;
+import static io.wcm.handler.media.testcontext.AppAemContext.DAM_PATH;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.CROP_TYPE_SMART;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.PN_BANNER;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.PN_CROP_TYPE;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.PN_NORMALIZED_HEIGHT;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.PN_NORMALIZED_WIDTH;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.canApply;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.getDimension;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.isMatchingSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.day.cq.dam.api.Asset;
+
+import io.wcm.handler.media.CropDimension;
+import io.wcm.handler.media.testcontext.AppAemContext;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.commons.contenttype.ContentType;
+
+@ExtendWith(AemContextExtension.class)
+class SmartCropTest {
+
+  private final AemContext context = AppAemContext.newAemContext();
+
+  private Asset asset;
+  private NamedDimension dimension16_10;
+
+  @BeforeEach
+  void setUp() {
+    asset = context.create().asset(DAM_PATH + "/image1.jpg", 160, 100, ContentType.JPEG);
+    dimension16_10 = new NamedDimension("16-10", 16, 10);
+  }
+
+  @Test
+  void testCanApply() {
+    assertTrue(canApply(null, null));
+    assertTrue(canApply(new CropDimension(0, 0, 10, 10, true), null));
+
+    assertFalse(canApply(null, 90));
+    assertFalse(canApply(new CropDimension(0, 0, 10, 10, true), 90));
+    assertFalse(canApply(new CropDimension(0, 0, 10, 10, false), null));
+  }
+
+  @Test
+  void testGetDimension() {
+    ImageProfile profile1 = new ImageProfileImpl(
+        context.create().resource("/conf/global/settings/dam/adminui-extension/imageprofile/profile1",
+        PN_CROP_TYPE, CROP_TYPE_SMART,
+        PN_BANNER, "16-10,160,100|4-3,40,30"));
+
+    assertNull(getDimension(profile1, 500, 500));
+    assertNamedDimension(getDimension(profile1, 320, 200), "16-10", 320, 200);
+    assertNamedDimension(getDimension(profile1, 400, 300), "4-3", 400, 300);
+  }
+
+  @Test
+  void testGetDimension_NoProfile() {
+    assertNull(getDimension(null, 100, 100));
+  }
+
+  @Test
+  void testIsMatchingSize_NoRenditionResource() {
+    // assume everything is ok if no "16-10" rendition exists (we have no other chance)
+    assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 80, 50));
+  }
+
+  @Test
+  void testIsMatchingSize_MatchesExact() {
+    setSmartCropRenditionNormalizedSize(0.5, 0.5); // results in 80x50 cropping area
+    assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 80, 50));
+  }
+
+  @Test
+  void testIsMatchingSize_MatchesSmaller() {
+    setSmartCropRenditionNormalizedSize(0.5, 0.5); // results in 80x50 cropping area
+    assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 40, 25));
+  }
+
+  @Test
+  void testIsMatchingSize_TooSmall() {
+    setSmartCropRenditionNormalizedSize(0.5, 0.5); // results in 80x50 cropping area
+    assertFalse(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 120, 75));
+  }
+
+  @Test
+  void testIsMatchingSize_InvalidNormalizedWidthHeight() {
+    setSmartCropRenditionNormalizedSize(0, 0);
+    // assume true because no valid normalized width/height provided - we do not know the cropping area
+    assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 80, 50));
+  }
+
+  private static void assertNamedDimension(NamedDimension namedDimension,
+      String expectedName, long expectedWith, long expectedHeight) {
+    assertNotNull(namedDimension);
+    assertEquals(expectedName, namedDimension.getName());
+    assertEquals(expectedWith, namedDimension.getWidth());
+    assertEquals(expectedHeight, namedDimension.getHeight());
+  }
+
+  private void setSmartCropRenditionNormalizedSize(double normalizedWith, double normalizedHeight) {
+    String renditionPath = asset.getPath() + "/" + JCR_CONTENT + "/" + RENDITIONS_FOLDER
+        + "/" + dimension16_10.getName() + "/" + JCR_CONTENT;
+    context.create().resource(renditionPath,
+        PN_NORMALIZED_WIDTH, normalizedWith,
+        PN_NORMALIZED_HEIGHT, normalizedHeight);
+  }
+
+}

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCropTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCropTest.java
@@ -129,9 +129,9 @@ class SmartCropTest {
   }
 
   private void setSmartCropRenditionNormalizedSize(double normalizedWith, double normalizedHeight) {
-    String renditionPath = asset.getPath() + "/" + JCR_CONTENT + "/" + RENDITIONS_FOLDER
+    String smartCropRenditionPath = asset.getPath() + "/" + JCR_CONTENT + "/" + RENDITIONS_FOLDER
         + "/" + dimension16_10.getName() + "/" + JCR_CONTENT;
-    context.create().resource(renditionPath,
+    context.create().resource(smartCropRenditionPath,
         PN_NORMALIZED_WIDTH, normalizedWith,
         PN_NORMALIZED_HEIGHT, normalizedHeight);
   }


### PR DESCRIPTION
ensure that the rendition produced by smart cropping (probably manually adjusted) is large enough to fill the requested image size (to avoid white borders)