### PR TITLE
DAM Media Source: Use cropping dimension bases on original rendition internally

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.14.16" date="not released">
+      <action type="update" dev="sseifert">
+        DAM Media Source: Use cropping dimension based on original rendition internally. Re-calculate webenabled rendition-based cropping coordinates when loading them from repository before starting the media processing, and not only when doing the actual cropping.
+      </action>
+    </release>
+
     <release version="1.14.14" date="2022-10-20">
       <action type="fix" dev="sseifert">
         Dynamic Media Support: Ensure smart-cropped renditions fulfill minimum size requirements.

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamAsset.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamAsset.java
@@ -67,11 +67,26 @@ public final class DamAsset extends SlingAdaptable implements Asset {
   public DamAsset(Media media, com.day.cq.dam.api.Asset damAsset, MediaHandlerConfig mediaHandlerConfig,
       DynamicMediaSupportService dynamicMediaSupportService, Adaptable adaptable) {
     this.damAsset = damAsset;
-    this.cropDimension = media.getCropDimension();
+    this.cropDimension = rescaleCropDimension(damAsset, media.getCropDimension());
     this.rotation = media.getRotation();
     this.defaultMediaArgs = media.getMediaRequest().getMediaArgs();
     this.damContext = new DamContext(damAsset, defaultMediaArgs, mediaHandlerConfig,
         dynamicMediaSupportService, adaptable);
+  }
+
+  /**
+   * Crop dimension stored in repository is always calucated against the web-enabled rendition of an asset.
+   * Rescale the crop-dimension here once to calculate it against the original image, which will be used for the actual
+   * cropping.
+   * @param asset Asset
+   * @param cropDimension Crop dimension from repository/input parameters
+   * @return Rescaled crop dimension
+   */
+  private static @Nullable CropDimension rescaleCropDimension(@NotNull com.day.cq.dam.api.Asset asset, @Nullable CropDimension cropDimension) {
+    if (cropDimension == null) {
+      return null;
+    }
+    return WebEnabledRenditionCropping.getCropDimensionForOriginal(asset, cropDimension);
   }
 
   @Override

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamAutoCropping.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamAutoCropping.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import com.day.cq.dam.api.Asset;
 
@@ -35,7 +34,6 @@ import io.wcm.handler.media.CropDimension;
 import io.wcm.handler.media.MediaArgs;
 import io.wcm.handler.media.format.MediaFormat;
 import io.wcm.handler.media.impl.ImageTransformation;
-import io.wcm.handler.mediasource.dam.AssetRendition;
 
 /**
  * Helper class for calculating crop dimensions for auto-cropping.
@@ -62,28 +60,12 @@ class DamAutoCropping {
   private CropDimension calculateAutoCropDimension(@NotNull MediaFormat mediaFormat) {
     double ratio = mediaFormat.getRatio();
     if (ratio > 0) {
-      RenditionMetadata rendition = DamAutoCropping.getWebRenditionForCropping(asset);
-      if (rendition != null && rendition.getWidth() > 0 && rendition.getHeight() > 0) {
+      RenditionMetadata rendition = new RenditionMetadata(asset.getOriginal());
+      if (rendition.getWidth() > 0 && rendition.getHeight() > 0) {
         return ImageTransformation.calculateAutoCropDimension(rendition.getWidth(), rendition.getHeight(), ratio);
       }
     }
     return null;
-  }
-
-  /**
-   * Get web first rendition for asset.
-   * This is the same logic as implemented in
-   * <code>/libs/cq/gui/components/authoring/editors/clientlibs/core/inlineediting/js/ImageEditor.js</code>.
-   * @param asset Asset
-   * @return Web rendition or null if none found
-   */
-  @SuppressWarnings("null")
-  public static @Nullable RenditionMetadata getWebRenditionForCropping(@NotNull Asset asset) {
-    return asset.getRenditions().stream()
-        .filter(AssetRendition::isWebRendition)
-        .findFirst()
-        .map(rendition -> new RenditionMetadata(rendition))
-        .orElse(null);
   }
 
 }

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/TransformedRenditionHandler.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/TransformedRenditionHandler.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 
 import io.wcm.handler.media.CropDimension;
 import io.wcm.handler.media.MediaArgs;
-import io.wcm.handler.media.format.Ratio;
 
 /**
  * Extended rendition handler supporting cropping and rotating of images.
@@ -102,36 +101,10 @@ public class TransformedRenditionHandler extends DefaultRenditionHandler {
     if (original == null || original.isVectorImage()) {
       return null;
     }
-    Double scaleFactor = getCropScaleFactor(original);
-    long scaledLeft = Math.round(cropDimension.getLeft() * scaleFactor);
-    long scaledTop = Math.round(cropDimension.getTop() * scaleFactor);
-    long scaledWidth = Math.round(cropDimension.getWidth() * scaleFactor);
-    if (scaledWidth > original.getWidth()) {
-      scaledWidth = original.getWidth();
-    }
-    long scaledHeight = Math.round(cropDimension.getHeight() * scaleFactor);
-    if (scaledHeight > original.getHeight()) {
-      scaledHeight = original.getHeight();
-    }
-    CropDimension scaledCropDimension = new CropDimension(scaledLeft, scaledTop, scaledWidth, scaledHeight,
-        cropDimension.isAutoCrop());
     return new VirtualTransformedRenditionMetadata(original.getRendition(),
-        rotateMapWidth(scaledCropDimension.getWidth(), scaledCropDimension.getHeight(), rotation),
-        rotateMapHeight(scaledCropDimension.getWidth(), scaledCropDimension.getHeight(), rotation),
-        mediaArgs.getEnforceOutputFileExtension(), scaledCropDimension, rotation);
-  }
-
-  /**
-   * The cropping coordinates are stored with coordinates relating to the web-enabled rendition. But we want
-   * to crop the original image, so we have to scale those values to match the coordinates in the original image.
-   * @return Scale factor
-   */
-  private double getCropScaleFactor(RenditionMetadata original) {
-    RenditionMetadata webEnabled = DamAutoCropping.getWebRenditionForCropping(getAsset());
-    if (original == null || webEnabled == null || original.getWidth() == 0 || webEnabled.getWidth() == 0) {
-      return 1d;
-    }
-    return Ratio.get(original.getWidth(), webEnabled.getWidth());
+        rotateMapWidth(cropDimension.getWidth(), cropDimension.getHeight(), rotation),
+        rotateMapHeight(cropDimension.getWidth(), cropDimension.getHeight(), rotation),
+        mediaArgs.getEnforceOutputFileExtension(), cropDimension, rotation);
   }
 
 }

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/WebEnabledRenditionCropping.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/WebEnabledRenditionCropping.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.dam.impl;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.day.cq.dam.api.Asset;
+
+import io.wcm.handler.media.CropDimension;
+import io.wcm.handler.media.format.Ratio;
+import io.wcm.handler.mediasource.dam.AssetRendition;
+
+/**
+ * Helper class for calculating crop dimensions for auto-cropping.
+ */
+final class WebEnabledRenditionCropping {
+
+  private WebEnabledRenditionCropping() {
+    // static methods only
+  }
+
+  /**
+   * Rescales the a crop dimension that is based on the web-enabled rendition to apply to the original rendition
+   * of the asset (which is the actual base for the cropping).
+   * @param asset Asset
+   * @param cropDimensionForWebRendition Crop dimension calculated based on web rendition
+   * @return Rendition or null if no match found
+   */
+  public static @NotNull CropDimension getCropDimensionForOriginal(@NotNull Asset asset,
+      @NotNull CropDimension cropDimensionForWebRendition) {
+    RenditionMetadata original = new RenditionMetadata(asset.getOriginal());
+    Double scaleFactor = getCropScaleFactor(asset, original);
+    long scaledLeft = Math.round(cropDimensionForWebRendition.getLeft() * scaleFactor);
+    long scaledTop = Math.round(cropDimensionForWebRendition.getTop() * scaleFactor);
+    long scaledWidth = Math.round(cropDimensionForWebRendition.getWidth() * scaleFactor);
+    if (scaledWidth > original.getWidth()) {
+      scaledWidth = original.getWidth();
+    }
+    long scaledHeight = Math.round(cropDimensionForWebRendition.getHeight() * scaleFactor);
+    if (scaledHeight > original.getHeight()) {
+      scaledHeight = original.getHeight();
+    }
+    return new CropDimension(scaledLeft, scaledTop, scaledWidth, scaledHeight,
+        cropDimensionForWebRendition.isAutoCrop());
+  }
+
+  /**
+   * The cropping coordinates are stored with coordinates relating to the web-enabled rendition. But we want
+   * to crop the original image, so we have to scale those values to match the coordinates in the original image.
+   * @return Scale factor
+   */
+  private static double getCropScaleFactor(@NotNull Asset asset, @NotNull RenditionMetadata original) {
+    RenditionMetadata webEnabled = getWebEnabledRendition(asset);
+    if (webEnabled == null || original.getWidth() == 0 || webEnabled.getWidth() == 0) {
+      return 1d;
+    }
+    return Ratio.get(original.getWidth(), webEnabled.getWidth());
+  }
+
+  /**
+   * Get web first rendition for asset.
+   * This is the same logic as implemented in
+   * <code>/libs/cq/gui/components/authoring/editors/clientlibs/core/inlineediting/js/ImageEditor.js</code>.
+   * @param asset Asset
+   * @return Web rendition or null if none found
+   */
+  private static @Nullable RenditionMetadata getWebEnabledRendition(@NotNull Asset asset) {
+    return asset.getRenditions().stream()
+        .filter(AssetRendition::isWebRendition)
+        .findFirst()
+        .map(RenditionMetadata::new)
+        .orElse(null);
+  }
+
+}

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/AutoCroppingMediaHandlerTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/AutoCroppingMediaHandlerTest.java
@@ -100,7 +100,7 @@ class AutoCroppingMediaHandlerTest {
     Rendition rendition = media.getRendition();
     assertEquals(215, rendition.getWidth());
     assertEquals(102, rendition.getHeight());
-    assertEquals("/content/dam/test.jpg/_jcr_content/renditions/original.image_file.215.102.0,5,400,194.file/test.jpg", media.getUrl());
+    assertEquals("/content/dam/test.jpg/_jcr_content/renditions/original.image_file.215.102.0,5,400,195.file/test.jpg", media.getUrl());
   }
 
   @Test
@@ -112,7 +112,7 @@ class AutoCroppingMediaHandlerTest {
     Rendition rendition = media.getRendition();
     assertEquals(215, rendition.getWidth());
     assertEquals(102, rendition.getHeight());
-    assertEquals("/content/dam/test.jpg/_jcr_content/renditions/original.image_file.215.102.0,5,400,194.file/test.jpg", media.getUrl());
+    assertEquals("/content/dam/test.jpg/_jcr_content/renditions/original.image_file.215.102.0,6,400,195.file/test.jpg", media.getUrl());
   }
 
   @Test

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/TransformedRenditionHandlerTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/TransformedRenditionHandlerTest.java
@@ -74,7 +74,7 @@ class TransformedRenditionHandlerTest {
     // generate web-enabled rendition
     webRendition = context.create().assetRenditionWebEnabled(asset, 200, 150);
 
-    cropDimension = new CropDimension(20, 10, 100, 30);
+    cropDimension = new CropDimension(40, 20, 200, 60);
   }
 
   @Test
@@ -95,7 +95,7 @@ class TransformedRenditionHandlerTest {
     TransformedRenditionHandler underTest = new TransformedRenditionHandler(cropDimension, null, damContext);
     assertEquals(1, underTest.getAvailableRenditions(new MediaArgs()).size());
     RenditionMetadata firstRendition = underTest.getAvailableRenditions(new MediaArgs()).iterator().next();
-    assertEquals("/content/dam/cropTest.jpg/jcr:content/renditions/original.image_file.100.30.20,10,120,40.file/cropTest.jpg",
+    assertEquals("/content/dam/cropTest.jpg/jcr:content/renditions/original.image_file.200.60.40,20,240,80.file/cropTest.jpg",
         firstRendition.getMediaPath(false));
   }
 

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/WebEnabledRenditionCroppingTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/WebEnabledRenditionCroppingTest.java
@@ -2,7 +2,7 @@
  * #%L
  * wcm.io
  * %%
- * Copyright (C) 2019 wcm.io
+ * Copyright (C) 2022 wcm.io
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,37 +21,47 @@ package io.wcm.handler.mediasource.dam.impl;
 
 import static com.day.cq.dam.api.DamConstants.PREFIX_ASSET_WEB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.day.cq.dam.api.Asset;
-import com.day.cq.dam.api.Rendition;
 
+import io.wcm.handler.media.CropDimension;
 import io.wcm.handler.media.testcontext.AppAemContext;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 @ExtendWith(AemContextExtension.class)
-class DamAutoCroppingTest {
+class WebEnabledRenditionCroppingTest {
 
   private final AemContext context = AppAemContext.newAemContext();
 
   @Test
-  @SuppressWarnings("null")
-  void testGetWebRenditionForCropping() {
+  void testGetCropDimensionForOriginal() {
     Asset asset = context.create().asset("/content/dam/asset1.jpg", 160, 90, "image/jpeg");
-    Rendition webRendition = context.create().assetRendition(asset, PREFIX_ASSET_WEB + ".80.45.jpg", 80, 45, "image/jpeg");
+    context.create().assetRendition(asset, PREFIX_ASSET_WEB + ".80.45.jpg", 80, 45, "image/jpeg");
 
-    RenditionMetadata result = DamAutoCropping.getWebRenditionForCropping(asset);
-    assertEquals(webRendition.getPath(), result.getRendition().getPath());
+    CropDimension result = WebEnabledRenditionCropping.getCropDimensionForOriginal(asset,
+        new CropDimension(10, 15, 20, 30));
+
+    assertEquals(20, result.getLeft());
+    assertEquals(30, result.getTop());
+    assertEquals(40, result.getWidth());
+    assertEquals(60, result.getHeight());
   }
 
   @Test
-  void testGetWebRenditionNotExisting() {
-    Asset assetWithoutRenditions = context.create().asset("/content/dam/asset2.jpg", 160, 90, "image/jpeg");
-    assertNull(DamAutoCropping.getWebRenditionForCropping(assetWithoutRenditions));
+  void testGetCropDimensionForOriginal_WebEnabledRenditionDoesNotExist() {
+    Asset asset = context.create().asset("/content/dam/asset2.jpg", 160, 90, "image/jpeg");
+
+    CropDimension result = WebEnabledRenditionCropping.getCropDimensionForOriginal(asset,
+        new CropDimension(10, 15, 20, 30));
+
+    assertEquals(10, result.getLeft());
+    assertEquals(15, result.getTop());
+    assertEquals(20, result.getWidth());
+    assertEquals(30, result.getHeight());
   }
 
 }


### PR DESCRIPTION
Re-calculate webenabled rendition-based cropping coordinates when loading them from repository before starting the media processing, and not only when doing the actual cropping.

Benefit: This avoids rounding errors when calculating internally everywhere with cropping coordinates based on the original rendition. This also matches better when taking Dynamic Media smart cropping into account, which is also based on the dimensions of the original image.