### PR TITLE
Dynamic Media Support: Fix smart-cropping rendition validation in case unconstrained media formats are used 

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         DAM Media Source: Use cropping dimension based on original rendition internally. Re-calculate webenabled rendition-based cropping coordinates when loading them from repository before starting the media processing, and not only when doing the actual cropping.
       </action>
+      <action type="fix" dev="sseifert">
+        Dynamic Media Support: Fix smart-cropping rendition validation in case unconstrained media formats are used (without exact size, e.g. only minimum width).
+      </action>
     </release>
 
     <release version="1.14.14" date="2022-10-20">

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamRendition.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamRendition.java
@@ -93,7 +93,7 @@ class DamRendition extends SlingAdaptable implements Rendition {
     // if no match was found and auto-cropping is enabled, try to build a transformed rendition
     // with automatically devised cropping parameters
     if (resolvedRendition == null && mediaArgs.isAutoCrop()) {
-      DamAutoCropping autoCropping = new DamAutoCropping(damContext.getAsset(), mediaArgs);
+      DamAutoCropping autoCropping = new DamAutoCropping(damContext, mediaArgs);
       List<CropDimension> autoCropDimensions = autoCropping.calculateAutoCropDimensions();
       for (CropDimension autoCropDimension : autoCropDimensions) {
         RenditionHandler renditionHandler = new TransformedRenditionHandler(autoCropDimension, rotation, damContext);

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaPath.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaPath.java
@@ -116,7 +116,7 @@ public final class DynamicMediaPath {
     // check for smart cropping when no cropping was applied by default, or auto-crop is enabled
     if (SmartCrop.canApply(cropDimension, rotation)) {
       // check for matching image profile and use predefined cropping preset if match found
-      NamedDimension smartCropDef = SmartCrop.getDimension(damContext.getImageProfile(), width, height);
+      NamedDimension smartCropDef = SmartCrop.getDimensionForWidthHeight(damContext.getImageProfile(), width, height);
       if (smartCropDef != null) {
         if (!SmartCrop.isMatchingSize(damContext.getAsset(), damContext.getResourceResolver(), smartCropDef, width, height)) {
           // smart crop should be applied, but selected area is too small, treat as invalid

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCrop.java
@@ -22,6 +22,8 @@ package io.wcm.handler.mediasource.dam.impl.dynamicmedia;
 import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
 import static com.day.cq.dam.api.DamConstants.RENDITIONS_FOLDER;
 
+import java.util.Arrays;
+
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
@@ -52,6 +54,16 @@ public final class SmartCrop {
    */
   public static final String PN_NORMALIZED_HEIGHT = "normalizedHeight";
 
+  /**
+   * Left margin (double value 0..1 as percentage of original image).
+   */
+  public static final String PN_LEFT = "left";
+
+  /**
+   * Top margin (double value 0..1 as percentage of original image).
+   */
+  public static final String PN_TOP = "top";
+
   private static final double MIN_NORMALIZED_WIDTH_HEIGHT = 0.0001;
   private static final Logger log = LoggerFactory.getLogger(SmartCrop.class);
 
@@ -66,8 +78,25 @@ public final class SmartCrop {
    * @param rotation Rotation
    * @return true if Smart Cropping can be applied
    */
-  static boolean canApply(@Nullable CropDimension cropDimension, @Nullable Integer rotation) {
+  public static boolean canApply(@Nullable CropDimension cropDimension, @Nullable Integer rotation) {
     return (cropDimension == null || cropDimension.isAutoCrop()) && rotation == null;
+  }
+
+  /**
+   * Checks DM image profile for a smart cropping definition matching the ratio of the requested ratio.
+   * @param imageProfile Image profile from DAM context (null if no is defined)
+   * @param requestedRatio Requested ratio
+   * @return Named dimension or null. The provided width/height can usually be ignored, because they
+   *         are the width/height from the image profile which only describe the aspect ratio, but not
+   *         any width/height values used in reality.
+   */
+  public static @Nullable NamedDimension getDimensionForRatio(@Nullable ImageProfile imageProfile, double requestedRatio) {
+    if (imageProfile == null) {
+      return null;
+    }
+    return imageProfile.getSmartCropDefinitions().stream()
+        .filter(def -> Ratio.matches(Ratio.get(def), requestedRatio))
+        .findFirst().orElse(null);
   }
 
   /**
@@ -77,14 +106,9 @@ public final class SmartCrop {
    * @param height Height
    * @return Smart cropping definition with requested width/height - or null if no match
    */
-  static @Nullable NamedDimension getDimension(@Nullable ImageProfile imageProfile, long width, long height) {
-    if (imageProfile == null) {
-      return null;
-    }
+  public static @Nullable NamedDimension getDimensionForWidthHeight(@Nullable ImageProfile imageProfile, long width, long height) {
     Double requestedRatio = Ratio.get(width, height);
-    NamedDimension matchingDimension = imageProfile.getSmartCropDefinitions().stream()
-        .filter(def -> Ratio.matches(Ratio.get(def), requestedRatio))
-        .findFirst().orElse(null);
+    NamedDimension matchingDimension = getDimensionForRatio(imageProfile, requestedRatio);
     if (matchingDimension != null) {
       // create new named dimension with actual requested width/height
       return new NamedDimension(matchingDimension.getName(), width, height);
@@ -92,6 +116,51 @@ public final class SmartCrop {
     else {
       return null;
     }
+  }
+
+  /**
+   * Gets the actual smart-cropped dimension for the given asset and smart cropping definition (aspect ratio).
+   * @param asset Asset
+   * @param resourceResolver Resource resolver
+   * @param smartCropDef Smart cropping definition from image profile
+   * @return Actual dimension of the smart cropping area or null if not found
+   */
+  @SuppressWarnings("java:S1075") // no filesystem paths
+  public static @Nullable CropDimension getCropDimensionForAsset(@NotNull Asset asset,
+      @NotNull ResourceResolver resourceResolver, @NotNull NamedDimension smartCropDef) {
+    // at this path smart cropping parameters may be stored for each ratio (esp. if manual cropping was applied)
+    String smartCropRenditionPath = asset.getPath()
+        + "/" + JCR_CONTENT
+        + "/" + RENDITIONS_FOLDER
+        + "/" + smartCropDef.getName()
+        + "/" + JCR_CONTENT;
+    Resource smartCropRendition = resourceResolver.getResource(smartCropRenditionPath);
+    if (smartCropRendition == null) {
+      // on AEMaaCS this path should always exist, in AEMaaCS SDK it seems to be created only when manual cropping
+      // is applied in the Assets UI
+      return null;
+    }
+    ValueMap props = smartCropRendition.getValueMap();
+    double leftPercentage = props.get(PN_LEFT, 0d);
+    double topPercentage = props.get(PN_TOP, 0d);
+    double widthPercentage = props.get(PN_NORMALIZED_WIDTH, 0d);
+    double heightPercentage = props.get(PN_NORMALIZED_HEIGHT, 0d);
+    Dimension originalDimension = AssetRendition.getDimension(asset.getOriginal());
+    if (originalDimension == null
+        || !isValidTopLeft(leftPercentage, topPercentage)
+        || !isValidWidthHeight(widthPercentage, heightPercentage)) {
+      // ignore smart cropping rendition with invalid dimension
+      return null;
+    }
+
+    // calculate actual cropping dimension
+    long originalWidth = originalDimension.getWidth();
+    long originalHeight = originalDimension.getHeight();
+    long left = Math.round(originalWidth * leftPercentage);
+    long top = Math.round(originalHeight * topPercentage);
+    long width = Math.round(originalWidth * widthPercentage);
+    long height = Math.round(originalHeight * heightPercentage);
+    return new CropDimension(left, top, width, height, true);
   }
 
   /**
@@ -104,41 +173,32 @@ public final class SmartCrop {
    * @param height Requested height
    * @return true if size is matching, or no width/height information for the cropped area is available
    */
-  @SuppressWarnings("java:S1075") // no filesystem paths
-  static boolean isMatchingSize(@NotNull Asset asset, @NotNull ResourceResolver resourceResolver,
+  public static boolean isMatchingSize(@NotNull Asset asset, @NotNull ResourceResolver resourceResolver,
       @NotNull NamedDimension smartCropDef, long width, long height) {
-    // at this path smart cropping parameters may be stored for each ratio (esp. if manual cropping was applied)
-    String smartCropRenditionPath = asset.getPath()
-        + "/" + JCR_CONTENT
-        + "/" + RENDITIONS_FOLDER
-        + "/" + smartCropDef.getName()
-        + "/" + JCR_CONTENT;
-    Resource smartCropRendition = resourceResolver.getResource(smartCropRenditionPath);
-    if (smartCropRendition == null) {
-      // if this rendition is not found in repository, we assume the size should be fine
-      // on AEMaaCS this path should always exist, in AEMaaCS SDK it seems to be created only when manual cropping
-      // is applied in the Assets UI
-      return true;
-    }
-    ValueMap props = smartCropRendition.getValueMap();
-    double normalizedWidth = props.get(PN_NORMALIZED_WIDTH, 0d);
-    double normalizedHeight = props.get(PN_NORMALIZED_HEIGHT, 0d);
-    Dimension originalDimension = AssetRendition.getDimension(asset.getOriginal());
-    if (normalizedWidth < MIN_NORMALIZED_WIDTH_HEIGHT || normalizedHeight < MIN_NORMALIZED_WIDTH_HEIGHT
-        || originalDimension == null) {
-      // skip further validation if dimensions are not found
+    CropDimension cropDimension = getCropDimensionForAsset(asset, resourceResolver, smartCropDef);
+    if (cropDimension == null) {
+      // no smart cropping rendition is not found in repository or it contains invalid values,
+      // we assume the size should be fine and skip further checking
       return true;
     }
 
     // check if smart cropping area is large enough
-    long croppedWidth = Math.round(originalDimension.getWidth() * normalizedWidth);
-    long croppedHeight = Math.round(originalDimension.getHeight() * normalizedHeight);
-    boolean isMatchingSize = (croppedWidth >= width || croppedHeight >= height);
+    long croppedWidth = cropDimension.getWidth();
+    long croppedHeight = cropDimension.getHeight();
+    boolean isMatchingSize = (cropDimension.getWidth() >= width || croppedHeight >= height);
     if (!isMatchingSize) {
       log.debug("Smart cropping area '{}' for asset {} is too small ({} x {}) for requested size {} x {}.",
           smartCropDef.getName(), asset.getPath(), croppedWidth, croppedHeight, width, height);
     }
     return isMatchingSize;
+  }
+
+  private static boolean isValidTopLeft(double... numbers) {
+    return Arrays.stream(numbers).allMatch(value -> value >= 0 && value <= 1);
+  }
+
+  private static boolean isValidWidthHeight(double... numbers) {
+    return Arrays.stream(numbers).allMatch(value -> value >= MIN_NORMALIZED_WIDTH_HEIGHT && value <= 1);
   }
 
 }

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplEnd2EndDynamicMediaSmartCropTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplEnd2EndDynamicMediaSmartCropTest.java
@@ -90,7 +90,7 @@ class MediaHandlerImplEnd2EndDynamicMediaSmartCropTest {
   }
 
   @Test
-  void testValidSmartCroppedRendition() {
+  void testValidSmartCroppedRenditionAndWidths() {
     Media media = getMediaWithWidths(80, 40);
     assertTrue(media.isValid());
 
@@ -114,9 +114,26 @@ class MediaHandlerImplEnd2EndDynamicMediaSmartCropTest {
     assertEquals(MediaInvalidReason.NOT_ENOUGH_MATCHING_RENDITIONS, media.getMediaInvalidReason());
   }
 
+  @Test
+  void testValidSmartCroppedRenditionOnlyRatio() {
+    Media media = getMediaWithRatio();
+    assertTrue(media.isValid());
+
+    List<Rendition> renditions = ImmutableList.copyOf(media.getRenditions());
+    assertEquals(1, renditions.size());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=80&hei=60&fit=stretch", renditions.get(0).getUrl());
+  }
+
   private Media getMediaWithWidths(long... widths) {
     return mediaHandler.get(asset.getPath())
         .pictureSource(new PictureSource(DummyMediaFormats.RATIO2).widths(widths))
+        .autoCrop(true)
+        .build();
+  }
+
+  private Media getMediaWithRatio() {
+    return mediaHandler.get(asset.getPath())
+        .mediaFormat(DummyMediaFormats.RATIO2)
         .autoCrop(true)
         .build();
   }

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCropTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCropTest.java
@@ -25,10 +25,14 @@ import static io.wcm.handler.media.testcontext.AppAemContext.DAM_PATH;
 import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.CROP_TYPE_SMART;
 import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.PN_BANNER;
 import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfileImpl.PN_CROP_TYPE;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.PN_LEFT;
 import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.PN_NORMALIZED_HEIGHT;
 import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.PN_NORMALIZED_WIDTH;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.PN_TOP;
 import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.canApply;
-import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.getDimension;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.getCropDimensionForAsset;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.getDimensionForRatio;
+import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.getDimensionForWidthHeight;
 import static io.wcm.handler.mediasource.dam.impl.dynamicmedia.SmartCrop.isMatchingSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,6 +47,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import com.day.cq.dam.api.Asset;
 
 import io.wcm.handler.media.CropDimension;
+import io.wcm.handler.media.format.Ratio;
 import io.wcm.handler.media.testcontext.AppAemContext;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -79,14 +84,37 @@ class SmartCropTest {
         PN_CROP_TYPE, CROP_TYPE_SMART,
         PN_BANNER, "16-10,160,100|4-3,40,30"));
 
-    assertNull(getDimension(profile1, 500, 500));
-    assertNamedDimension(getDimension(profile1, 320, 200), "16-10", 320, 200);
-    assertNamedDimension(getDimension(profile1, 400, 300), "4-3", 400, 300);
+    assertNull(getDimensionForRatio(profile1, 1d));
+    assertNull(getDimensionForWidthHeight(profile1, 500, 500));
+
+    assertNamedDimension(getDimensionForRatio(profile1, Ratio.get(16, 10)), "16-10", 160, 100);
+    assertNamedDimension(getDimensionForWidthHeight(profile1, 320, 200), "16-10", 320, 200);
+
+    assertNamedDimension(getDimensionForRatio(profile1, Ratio.get(4, 3)), "4-3", 40, 30);
+    assertNamedDimension(getDimensionForWidthHeight(profile1, 400, 300), "4-3", 400, 300);
   }
 
   @Test
   void testGetDimension_NoProfile() {
-    assertNull(getDimension(null, 100, 100));
+    assertNull(getDimensionForRatio(null, 1d));
+    assertNull(getDimensionForWidthHeight(null, 100, 100));
+  }
+
+  @Test
+  void testGetCropDimensionForAsset_NoRenditionResource() {
+    assertNull(getCropDimensionForAsset(asset, context.resourceResolver(), dimension16_10));
+  }
+
+  @Test
+  void testGetCropDimensionForAsset() {
+    prepareSmartCropRendition(0.1, 0.2, 0.5, 0.5); // results in 80x50 cropping area
+    CropDimension cropDimension = getCropDimensionForAsset(asset, context.resourceResolver(), dimension16_10);
+
+    assertNotNull(cropDimension);
+    assertEquals(16, cropDimension.getLeft());
+    assertEquals(20, cropDimension.getTop());
+    assertEquals(80, cropDimension.getWidth());
+    assertEquals(50, cropDimension.getHeight());
   }
 
   @Test
@@ -97,25 +125,25 @@ class SmartCropTest {
 
   @Test
   void testIsMatchingSize_MatchesExact() {
-    setSmartCropRenditionNormalizedSize(0.5, 0.5); // results in 80x50 cropping area
+    prepareSmartCropRendition(0, 0, 0.5, 0.5); // results in 80x50 cropping area
     assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 80, 50));
   }
 
   @Test
   void testIsMatchingSize_MatchesSmaller() {
-    setSmartCropRenditionNormalizedSize(0.5, 0.5); // results in 80x50 cropping area
+    prepareSmartCropRendition(0, 0, 0.5, 0.5); // results in 80x50 cropping area
     assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 40, 25));
   }
 
   @Test
   void testIsMatchingSize_TooSmall() {
-    setSmartCropRenditionNormalizedSize(0.5, 0.5); // results in 80x50 cropping area
+    prepareSmartCropRendition(0, 0, 0.5, 0.5); // results in 80x50 cropping area
     assertFalse(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 120, 75));
   }
 
   @Test
   void testIsMatchingSize_InvalidNormalizedWidthHeight() {
-    setSmartCropRenditionNormalizedSize(0, 0);
+    prepareSmartCropRendition(0, 0, 0, 0);
     // assume true because no valid normalized width/height provided - we do not know the cropping area
     assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 80, 50));
   }
@@ -128,10 +156,12 @@ class SmartCropTest {
     assertEquals(expectedHeight, namedDimension.getHeight());
   }
 
-  private void setSmartCropRenditionNormalizedSize(double normalizedWith, double normalizedHeight) {
+  private void prepareSmartCropRendition(double left, double top, double normalizedWith, double normalizedHeight) {
     String smartCropRenditionPath = asset.getPath() + "/" + JCR_CONTENT + "/" + RENDITIONS_FOLDER
         + "/" + dimension16_10.getName() + "/" + JCR_CONTENT;
     context.create().resource(smartCropRenditionPath,
+        PN_LEFT, left,
+        PN_TOP, top,
         PN_NORMALIZED_WIDTH, normalizedWith,
         PN_NORMALIZED_HEIGHT, normalizedHeight);
   }


### PR DESCRIPTION
unconstrained = without exact size, e.g. only ratio or only ratio and minimum width