### PR TITLE
Dynamic Media Support: Apply fail-safe approach when normalized width/height provided by Dynamic Media for smart cropping are not matching the defined aspect ratio.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.14.18" date="not released">
+      <action type="fix" dev="sseifert">
+        Dynamic Media Support: Apply fail-safe approach when normalized width/height provided by Dynamic Media for smart cropping are not matching the defined aspect ratio.
+      </action>
+    </release>
+
     <release version="1.14.16" date="2022-10-22">
       <action type="update" dev="sseifert">
         DAM Media Source: Use cropping dimension based on original rendition internally. Re-calculate webenabled rendition-based cropping coordinates when loading them from repository before starting the media processing, and not only when doing the actual cropping.

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCropTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/SmartCropTest.java
@@ -118,6 +118,30 @@ class SmartCropTest {
   }
 
   @Test
+  void testGetCropDimensionForAsset_WidthDeviation() {
+    prepareSmartCropRendition(0.1, 0.2, 0.75, 0.5); // results in 120x50 cropping area, treated as 80x50
+    CropDimension cropDimension = getCropDimensionForAsset(asset, context.resourceResolver(), dimension16_10);
+
+    assertNotNull(cropDimension);
+    assertEquals(16, cropDimension.getLeft());
+    assertEquals(20, cropDimension.getTop());
+    assertEquals(80, cropDimension.getWidth());
+    assertEquals(50, cropDimension.getHeight());
+  }
+
+  @Test
+  void testGetCropDimensionForAsset_HeightDeviation() {
+    prepareSmartCropRendition(0.1, 0.2, 0.5, 0.75); // results in 80x75 cropping area, treated as 80x50
+    CropDimension cropDimension = getCropDimensionForAsset(asset, context.resourceResolver(), dimension16_10);
+
+    assertNotNull(cropDimension);
+    assertEquals(16, cropDimension.getLeft());
+    assertEquals(20, cropDimension.getTop());
+    assertEquals(80, cropDimension.getWidth());
+    assertEquals(50, cropDimension.getHeight());
+  }
+
+  @Test
   void testIsMatchingSize_NoRenditionResource() {
     // assume everything is ok if no "16-10" rendition exists (we have no other chance)
     assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 80, 50));
@@ -138,6 +162,42 @@ class SmartCropTest {
   @Test
   void testIsMatchingSize_TooSmall() {
     prepareSmartCropRendition(0, 0, 0.5, 0.5); // results in 80x50 cropping area
+    assertFalse(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 120, 75));
+  }
+
+  @Test
+  void testIsMatchingSize_MatchesExact_WidthDeviation() {
+    prepareSmartCropRendition(0, 0, 0.75, 0.5); // results in 120x50 cropping area, treated as 80x50
+    assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 80, 50));
+  }
+
+  @Test
+  void testIsMatchingSize_MatchesSmaller_WidthDeviation() {
+    prepareSmartCropRendition(0, 0, 0.75, 0.5); // results in 120x50 cropping area, treated as 80x50
+    assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 40, 25));
+  }
+
+  @Test
+  void testIsMatchingSize_TooSmall_WidthDeviation() {
+    prepareSmartCropRendition(0, 0, 0.75, 0.5); // results in 120x50 cropping area, treated as 80x50
+    assertFalse(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 120, 75));
+  }
+
+  @Test
+  void testIsMatchingSize_MatchesExact_HeightDeviation() {
+    prepareSmartCropRendition(0, 0, 0.75, 0.5); // results in 80x75 cropping area, treated as 80x50
+    assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 80, 50));
+  }
+
+  @Test
+  void testIsMatchingSize_MatchesSmaller_HeightDeviation() {
+    prepareSmartCropRendition(0, 0, 0.75, 0.5); // results in 80x75 cropping area, treated as 80x50
+    assertTrue(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 40, 25));
+  }
+
+  @Test
+  void testIsMatchingSize_TooSmall_HeightDeviation() {
+    prepareSmartCropRendition(0, 0, 0.75, 0.5); // results in 80x75 cropping area, treated as 80x50
     assertFalse(isMatchingSize(asset, context.resourceResolver(), dimension16_10, 120, 75));
   }
 


### PR DESCRIPTION
DM may provide normalizedWidth/normalizedHeight properties resulting in width/height values not matching with the aspect ratio defined for the image sizes in the image profile. depending on profile image size and original image size, the deviation can be quite large (we have seen up to 45%).

As a fail-safe approach use the smaller edge from either normalizedWidth or normalizedHeight to validate the rendition size to be on the safe side.