### PR TITLE
clear transformation fix for child nodes

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.15.2" date="not released">
+      <action type="fix" dev="amey-tripathi">
+        File Upload Granite UI component: Fix "Clear Transformation" button when namePrefix with sub-node is used.
+      </action>
+    </release>
+
     <release version="1.15.0" date="2022-11-17">
       <action type="add" dev="sseifert">
         Add Rendition.getUriTemplate method to build URI templates for getting scaled or auto-cropped renditions of an asset with the restrictions of the rendition e.g. aspect ratio.

--- a/src/main/webapp/app-root/components/granite/form/fileupload/fileupload.jsp
+++ b/src/main/webapp/app-root/components/granite/form/fileupload/fileupload.jsp
@@ -144,8 +144,14 @@ if (contentResource != null) {
   propFileNameDefault = namePrefix + mediaHandlerConfig.getMediaInlineNodeName() + "Name";
   propFileReferenceDefault = namePrefix + mediaHandlerConfig.getMediaRefProperty();
 
-  // check if any transformations are defined
-  ValueMap contentProps = contentResource.getValueMap();
+  ValueMap contentProps = ValueMap.EMPTY;
+  /* check if namePrefix has a trailing /. If yes that means that we're dealing with a child node */
+  if (namePrefix.lastIndexOf('/') > 2) {
+    Resource childNode = contentResource.getChild(namePrefix.substring(2, namePrefix.length() - 1));
+    contentProps = (childNode != null) ? childNode.getValueMap() : contentProps;
+  }
+  else contentProps = contentResource.getValueMap();
+
   hasTransformation = (contentProps.get(mediaHandlerConfig.getMediaCropProperty(), String.class) != null)
       || (contentProps.get(mediaHandlerConfig.getMediaRotationProperty(), String.class) != null)
       || (contentProps.get(mediaHandlerConfig.getMediaMapProperty(), String.class) != null);

--- a/src/main/webapp/app-root/components/granite/form/fileupload/fileupload.jsp
+++ b/src/main/webapp/app-root/components/granite/form/fileupload/fileupload.jsp
@@ -144,14 +144,8 @@ if (contentResource != null) {
   propFileNameDefault = namePrefix + mediaHandlerConfig.getMediaInlineNodeName() + "Name";
   propFileReferenceDefault = namePrefix + mediaHandlerConfig.getMediaRefProperty();
 
-  ValueMap contentProps = ValueMap.EMPTY;
-  /* check if namePrefix has a trailing /. If yes that means that we're dealing with a child node */
-  if (namePrefix.lastIndexOf('/') > 2) {
-    Resource childNode = contentResource.getChild(namePrefix.substring(2, namePrefix.length() - 1));
-    contentProps = (childNode != null) ? childNode.getValueMap() : contentProps;
-  }
-  else contentProps = contentResource.getValueMap();
-
+  // check if any transformations are defined
+  ValueMap contentProps = getPropertiesContentResource(contentResource, namePrefix).getValueMap();
   hasTransformation = (contentProps.get(mediaHandlerConfig.getMediaCropProperty(), String.class) != null)
       || (contentProps.get(mediaHandlerConfig.getMediaRotationProperty(), String.class) != null)
       || (contentProps.get(mediaHandlerConfig.getMediaMapProperty(), String.class) != null);
@@ -234,4 +228,25 @@ if (!dataProps.isEmpty()) {
 dispatcher = slingRequest.getRequestDispatcher(pathField);
 dispatcher.include(slingRequest, slingResponse);
 
+%><%!
+/**
+ * With setting nameprefix to a subnode like "./mySubNode/" it's possible to store the media reference
+ * and the related transformation paramters in another node. This method tries to detect this, and
+ * returns the child node where the properties are stored in.
+ * @param contentResource Content resource of the current edit dialog
+ * @return Sub node content resource or the current content resource
+ */
+Resource getPropertiesContentResource(Resource contentResource, String namePrefix) {
+  // the prefix is expected to prefix existing property names. use a dummy property name to get the parent path -
+  // which may be the same path of the content resource, or pointint to a sub resource
+  String dummyPropertyPath = namePrefix + "dummy";
+  String subResourcePath = ResourceUtil.getParent(dummyPropertyPath);
+  Resource propertiesContentResource = contentResource.getChild(subResourcePath);
+  if (propertiesContentResource != null) {
+    return propertiesContentResource;
+  }
+  else {
+    return contentResource;
+  }
+}
 %>


### PR DESCRIPTION
**Problem:** If the `namePrefix` attribute is set to something like `./child/`, it would make all the other properties like `fileReference` etc to be fetched from a child node named `child`, however the `hastransformation` check still fetches properties from the parent node and would show incorrect status of existing transformation.

**Proposed solution:** Get properties from the child node named with `namePrefix` to check if transformation properties are stored there if the `namePrefix` has a trailing `/`.