### PR TITLE
MediaHandler: Build HTML element markup on-demand

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.15.2" date="not released">
+      <action type="update" dev="sseifert">
+        MediaHandler: Build HTML element markup on-demand based on the current status of media when the element is requested. This allows to react on results of media post processors, and avoids building the element if not required.
+      </action>
       <action type="fix" dev="amey-tripathi">
         File Upload Granite UI component: Fix "Clear Transformation" button when namePrefix with sub-node is used.
       </action>

--- a/src/main/java/io/wcm/handler/media/Media.java
+++ b/src/main/java/io/wcm/handler/media/Media.java
@@ -21,6 +21,7 @@ package io.wcm.handler.media;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -49,6 +50,7 @@ public final class Media {
   private final @NotNull MediaSource mediaSource;
   private @NotNull MediaRequest mediaRequest;
   private HtmlElement<?> element;
+  private Function<Media, HtmlElement<?>> elementBuilder;
   private String url;
   private Asset asset;
   private Collection<Rendition> renditions;
@@ -96,6 +98,10 @@ public final class Media {
    */
   @JsonIgnore
   public HtmlElement<?> getElement() {
+    if (this.element == null && this.elementBuilder != null) {
+      this.element = this.elementBuilder.apply(this);
+      this.elementBuilder = null;
+    }
     return this.element;
   }
 
@@ -104,17 +110,18 @@ public final class Media {
    */
   @JsonIgnore
   public String getMarkup() {
-    if (markup == null && this.element != null) {
-      if (this.element instanceof Span) {
+    HtmlElement<?> el = getElement();
+    if (markup == null && el != null) {
+      if (el instanceof Span) {
         // in case of span get inner HTML markup, do not include span element itself
         StringBuilder result = new StringBuilder();
-        for (Element child : this.element.getChildren()) {
+        for (Element child : el.getChildren()) {
           result.append(child.toString());
         }
         markup = result.toString();
       }
       else {
-        markup = this.element.toString();
+        markup = el.toString();
       }
     }
     return markup;
@@ -122,9 +129,19 @@ public final class Media {
 
   /**
    * @param value Html element
+   * @deprecated Use {@link #setElementBuilder(Function)} to build anchor on-demand
    */
+  @Deprecated
   public void setElement(HtmlElement<?> value) {
     this.element = value;
+    this.markup = null;
+  }
+
+  /**
+   * @param value Function that builds the HTML element representation on demand
+   */
+  public void setElementBuilder(Function<Media, HtmlElement<?>> value) {
+    this.elementBuilder = value;
     this.markup = null;
   }
 

--- a/src/main/java/io/wcm/handler/media/impl/MediaHandlerImpl.java
+++ b/src/main/java/io/wcm/handler/media/impl/MediaHandlerImpl.java
@@ -191,14 +191,16 @@ public final class MediaHandlerImpl implements MediaHandler {
       // generate markup (if markup builder is available) - first accepting wins
       List<Class<? extends MediaMarkupBuilder>> mediaMarkupBuilders = mediaHandlerConfig.getMarkupBuilders();
       if (mediaMarkupBuilders != null) {
-        for (Class<? extends MediaMarkupBuilder> mediaMarkupBuilderClass : mediaMarkupBuilders) {
-          MediaMarkupBuilder mediaMarkupBuilder = AdaptTo.notNull(adaptable, mediaMarkupBuilderClass);
-          if (mediaMarkupBuilder.accepts(media)) {
-            log.trace("Apply media markup builder ({}): {}", mediaMarkupBuilderClass, mediaRequest);
-            media.setElement(mediaMarkupBuilder.build(media));
-            break;
+        media.setElementBuilder(m -> {
+          for (Class<? extends MediaMarkupBuilder> mediaMarkupBuilderClass : mediaMarkupBuilders) {
+            MediaMarkupBuilder mediaMarkupBuilder = AdaptTo.notNull(adaptable, mediaMarkupBuilderClass);
+            if (mediaMarkupBuilder.accepts(m)) {
+              log.trace("Apply media markup builder ({}): {}", mediaMarkupBuilderClass, mediaRequest);
+              return mediaMarkupBuilder.build(m);
+            }
           }
-        }
+          return null;
+        });
       }
 
       // postprocess media request after resolving

--- a/src/main/java/io/wcm/handler/media/package-info.java
+++ b/src/main/java/io/wcm/handler/media/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Media Handler API.
  */
-@org.osgi.annotation.versioning.Version("1.18")
+@org.osgi.annotation.versioning.Version("1.19")
 package io.wcm.handler.media;

--- a/src/test/java/io/wcm/handler/media/MediaTest.java
+++ b/src/test/java/io/wcm/handler/media/MediaTest.java
@@ -68,6 +68,7 @@ class MediaTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void testElement() {
     Div div = new Div();
     div.setText("test");
@@ -75,6 +76,16 @@ class MediaTest {
     underTest.setElement(div);
     assertSame(div, underTest.getElement());
     assertEquals("<div>test</div>", underTest.getMarkup());
+  }
+
+  @Test
+  void testElementBuilder() {
+    Div div = new Div();
+    div.setText("test");
+
+    underTest.setElementBuilder(m -> div.setTitle("title1"));
+    assertSame(div, underTest.getElement());
+    assertEquals("<div title=\"title1\">test</div>", underTest.getMarkup());
   }
 
   @Test

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplTest.java
@@ -105,9 +105,9 @@ class MediaHandlerImplTest {
     assertTrue(media.isValid());
     assertEquals("http://xyz/content/dummymedia.post1/item1/pre1.gif", media.getUrl());
     assertNotNull(media.getElement());
-    assertEquals("http://xyz/content/dummymedia/item1/pre1.gif", media.getElement().getAttributeValue("src"));
+    assertEquals("http://xyz/content/dummymedia.post1/item1/pre1.gif", media.getElement().getAttributeValue("src"));
 
-    assertEquals("<img src=\"http://xyz/content/dummymedia/item1/pre1.gif\" />", media.getMarkup());
+    assertEquals("<img src=\"http://xyz/content/dummymedia.post1/item1/pre1.gif\" />", media.getMarkup());
   }
 
   @Test


### PR DESCRIPTION
Build HTML element markup on-demand based on the current status of media when the element is requested. This allows to react on results of media post processors, and avoids building the element if not required.