### PR TITLE
Embed Guava to elminate run time dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ npm-debug.log
 .vlt
 .vlt-sync*
 .brackets.json
+dependency-reduced-pom.xml

--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.15.6" date="not released">
+      <action type="update" dev="sseifert">
+        Embed Guava to elminate run time dependency. Guava is used for caching and concurrency features.
+      </action>
+    </release>
+
     <release version="1.15.4" date="2023-02-24">
       <action type="update" dev="sseifert">
         Switch to Java 11 as minimum version.

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.handler.commons</artifactId>
       <version>1.4.4</version>
@@ -236,6 +243,8 @@
               javax.annotation;version="[0.0,2)",\
               <!-- Package version change between AEM 6.2 and AEM 6.3 -->\
               com.day.cq.dam.api.handler;version="[1.0,3)",\
+              <!-- Guava is embedded -->\
+              !com.google.common.*,\
               *
           </bnd>
         </configuration>
@@ -252,6 +261,45 @@
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
+      </plugin>
+
+      <!-- Embed shaded version of Guava to avoid classpath issues in unit tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <artifactSet>
+            <includes>
+              <include>com.google.guava:guava</include>
+            </includes>
+          </artifactSet>
+          <relocations>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>io.wcm.handler.media.shaded.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.thirdparty</pattern>
+              <shadedPattern>io.wcm.handler.media.shaded.com.google.thirdparty</shadedPattern>
+            </relocation>
+          </relocations>
+          <filters>
+            <filter>
+              <artifact>com.google.guava:guava</artifact>
+              <excludes>
+                <exclude>META-INF/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Alternative to https://github.com/wcm-io/io.wcm.handler.media/pull/19 - embed Guava (latest version)

Although it's easy to replace Guava cache with Caffeine, and the ThreadBuilderFactory can be reimplemented with a few lines of code, it's not so easy to replace the concurrent [Striped](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/util/concurrent/Striped.html) class which is used for lazy weak locking when updating the rendition metadata.