### PR TITLE
Eliminate usage of org.apache.sling.commons.json

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert" issue="14">
         MediaHandlerConfig: Make list of allowed IPE editor types configurable (defaults to "image").
       </action>
+      <action type="update" dev="sseifert">
+        DefaultMediaFormatListProvider, MediaFormatValidateServlet: Eliminate usage of org.apache.sling.commons.json.
+      </action>
     </release>
 
     <release version="1.15.8" date="2023-09-08">

--- a/changes.xml
+++ b/changes.xml
@@ -27,7 +27,7 @@
       <action type="update" dev="sseifert" issue="14">
         MediaHandlerConfig: Make list of allowed IPE editor types configurable (defaults to "image").
       </action>
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="26">
         DefaultMediaFormatListProvider, MediaFormatValidateServlet: Eliminate usage of org.apache.sling.commons.json.
       </action>
     </release>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,23 @@
       <version>1.5.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>2.8.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path-assert</artifactId>
+      <version>2.8.0</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Java ImageIO Support for TIFF -->
     <dependency>

--- a/src/main/java/io/wcm/handler/media/format/impl/DefaultMediaFormatListProvider.java
+++ b/src/main/java/io/wcm/handler/media/format/impl/DefaultMediaFormatListProvider.java
@@ -20,7 +20,9 @@
 package io.wcm.handler.media.format.impl;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import javax.servlet.Servlet;
@@ -30,11 +32,13 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
-import org.apache.sling.commons.json.JSONArray;
-import org.apache.sling.commons.json.JSONException;
-import org.apache.sling.commons.json.JSONObject;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.wcm.handler.media.format.MediaFormat;
 import io.wcm.handler.media.format.MediaFormatHandler;
@@ -50,47 +54,39 @@ import io.wcm.wcm.commons.contenttype.FileExtension;
     "sling.servlet.resourceTypes=sling/servlet/default",
     "sling.servlet.methods=" + HttpConstants.METHOD_GET
 })
-@SuppressWarnings("deprecation")
 public final class DefaultMediaFormatListProvider extends SlingSafeMethodsServlet {
   private static final long serialVersionUID = 1L;
 
   @Override
   protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
-    try {
+    // get list of media formats for current medialib path
+    Set<MediaFormat> mediaFormats = getMediaFormats(request);
 
-      // get list of media formats for current medialib path
-      Set<MediaFormat> mediaFormats = getMediaFormats(request);
-
-      response.setContentType(ContentType.JSON);
-
-      JSONArray mediaFormatList = new JSONArray();
-
-      if (mediaFormats != null) {
-        for (MediaFormat mediaFormat : mediaFormats) {
-          if (!mediaFormat.isInternal()) {
-            JSONObject mediaFormatItem = new JSONObject();
-            mediaFormatItem.put("name", mediaFormat.getName());
-            mediaFormatItem.put("text", mediaFormat.toString());
-            mediaFormatItem.put("width", mediaFormat.getWidth());
-            mediaFormatItem.put("height", mediaFormat.getHeight());
-            mediaFormatItem.put("widthMin", mediaFormat.getMinWidth());
-            mediaFormatItem.put("heightMin", mediaFormat.getMinHeight());
-            mediaFormatItem.put("widthHeightMin", mediaFormat.getMinWidthHeight());
-            mediaFormatItem.put("isImage", mediaFormat.isImage());
-            mediaFormatItem.put("ratio", mediaFormat.getRatio());
-            mediaFormatItem.put("ratioWidth", mediaFormat.getRatioWidthAsDouble());
-            mediaFormatItem.put("ratioHeight", mediaFormat.getRatioHeightAsDouble());
-            mediaFormatItem.put("ratioDisplayString", mediaFormat.getRatioDisplayString());
-            mediaFormatList.put(mediaFormatItem);
-          }
+    List<MediaFormatItem> mediaFormatList = new ArrayList<>();
+    if (mediaFormats != null) {
+      for (MediaFormat mediaFormat : mediaFormats) {
+        if (!mediaFormat.isInternal()) {
+          MediaFormatItem mediaFormatItem = new MediaFormatItem();
+          mediaFormatItem.name = mediaFormat.getName();
+          mediaFormatItem.text = mediaFormat.toString();
+          mediaFormatItem.width = mediaFormat.getWidth();
+          mediaFormatItem.height = mediaFormat.getHeight();
+          mediaFormatItem.widthMin = mediaFormat.getMinWidth();
+          mediaFormatItem.heightMin = mediaFormat.getMinHeight();
+          mediaFormatItem.widthHeightMin = mediaFormat.getMinWidthHeight();
+          mediaFormatItem.isImage = mediaFormat.isImage();
+          mediaFormatItem.ratio = mediaFormat.getRatio();
+          mediaFormatItem.ratioWidth = mediaFormat.getRatioWidthAsDouble();
+          mediaFormatItem.ratioHeight = mediaFormat.getRatioHeightAsDouble();
+          mediaFormatItem.ratioDisplayString = mediaFormat.getRatioDisplayString();
+          mediaFormatList.add(mediaFormatItem);
         }
       }
+    }
 
-      response.getWriter().write(mediaFormatList.toString());
-    }
-    catch (JSONException ex) {
-      throw new ServletException(ex);
-    }
+    // serialize to JSON using Jackson
+    response.setContentType(ContentType.JSON);
+    response.getWriter().write(new ObjectMapper().writeValueAsString(mediaFormatList));
   }
 
   protected Set<MediaFormat> getMediaFormats(SlingHttpServletRequest request) {
@@ -101,6 +97,72 @@ public final class DefaultMediaFormatListProvider extends SlingSafeMethodsServle
     else {
       return Collections.emptySet();
     }
+  }
+
+  @JsonInclude(Include.NON_NULL)
+  static class MediaFormatItem {
+    private String name;
+    private String text;
+    private long width;
+    private long height;
+    private long widthMin;
+    private long heightMin;
+    private long widthHeightMin;
+    private boolean isImage;
+    private double ratio;
+    private double ratioWidth;
+    private double ratioHeight;
+    private String ratioDisplayString;
+
+    public String getName() {
+      return this.name;
+    }
+
+    public String getText() {
+      return this.text;
+    }
+
+    public long getWidth() {
+      return this.width;
+    }
+
+    public long getHeight() {
+      return this.height;
+    }
+
+    public long getWidthMin() {
+      return this.widthMin;
+    }
+
+    public long getHeightMin() {
+      return this.heightMin;
+    }
+
+    public long getWidthHeightMin() {
+      return this.widthHeightMin;
+    }
+
+    @JsonProperty("isImage")
+    public boolean isImage() {
+      return this.isImage;
+    }
+
+    public double getRatio() {
+      return this.ratio;
+    }
+
+    public double getRatioWidth() {
+      return this.ratioWidth;
+    }
+
+    public double getRatioHeight() {
+      return this.ratioHeight;
+    }
+
+    public String getRatioDisplayString() {
+      return this.ratioDisplayString;
+    }
+
   }
 
 }

--- a/src/main/java/io/wcm/handler/media/impl/MediaFormatValidateServlet.java
+++ b/src/main/java/io/wcm/handler/media/impl/MediaFormatValidateServlet.java
@@ -34,8 +34,6 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
-import org.apache.sling.commons.json.JSONException;
-import org.apache.sling.commons.json.JSONObject;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
@@ -43,6 +41,9 @@ import org.osgi.service.component.annotations.Component;
 import com.day.cq.i18n.I18n;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.wcm.handler.media.Media;
 import io.wcm.handler.media.MediaArgs.MediaFormatOption;
@@ -63,7 +64,6 @@ import io.wcm.wcm.commons.contenttype.FileExtension;
     selectors = MediaFormatValidateServlet.SELECTOR,
     resourceTypes = "sling/servlet/default",
     methods = HttpConstants.METHOD_GET)
-@SuppressWarnings("deprecation")
 public final class MediaFormatValidateServlet extends SlingSafeMethodsServlet {
   private static final long serialVersionUID = 1L;
 
@@ -112,20 +112,15 @@ public final class MediaFormatValidateServlet extends SlingSafeMethodsServlet {
         .build();
 
     // response
-    try {
-      JSONObject result = new JSONObject();
-      result.put("valid", media.isValid());
-      if (!media.isValid()) {
-        I18n i18n = getI18n(request);
-        result.put("reason", getI18nText(i18n, getMediaInvalidReasonI18nKeyOrMessage(media)));
-        result.put("reasonTitle", getI18nText(i18n, ASSET_INVALID_I18N_KEY));
-      }
-      response.setContentType(ContentType.JSON);
-      response.getWriter().write(result.toString());
+    ResultResponse result = new ResultResponse();
+    result.valid = media.isValid();
+    if (!media.isValid()) {
+      I18n i18n = getI18n(request);
+      result.reason = getI18nText(i18n, getMediaInvalidReasonI18nKeyOrMessage(media));
+      result.reasonTitle = getI18nText(i18n, ASSET_INVALID_I18N_KEY);
     }
-    catch (JSONException ex) {
-      throw new ServletException(ex);
-    }
+    response.setContentType(ContentType.JSON);
+    response.getWriter().write(new ObjectMapper().writeValueAsString(result));
   }
 
   private String getMediaInvalidReasonI18nKeyOrMessage(@NotNull Media media) {
@@ -155,6 +150,27 @@ public final class MediaFormatValidateServlet extends SlingSafeMethodsServlet {
       return new I18n(resourceBundle);
     }
     return new I18n(request);
+  }
+
+  @JsonInclude(Include.NON_NULL)
+  static class ResultResponse {
+
+    private boolean valid;
+    private String reason;
+    private String reasonTitle;
+
+    public boolean isValid() {
+      return this.valid;
+    }
+
+    public String getReason() {
+      return this.reason;
+    }
+
+    public String getReasonTitle() {
+      return this.reasonTitle;
+    }
+
   }
 
 }

--- a/src/test/java/io/wcm/handler/media/format/impl/DefaultMediaFormatListProviderTest.java
+++ b/src/test/java/io/wcm/handler/media/format/impl/DefaultMediaFormatListProviderTest.java
@@ -19,12 +19,16 @@
  */
 package io.wcm.handler.media.format.impl;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 
 import io.wcm.handler.media.testcontext.AppAemContext;
 import io.wcm.handler.media.testcontext.DummyMediaFormats;
@@ -48,9 +52,11 @@ class DefaultMediaFormatListProviderTest {
     underTest.service(context.request(), context.response());
 
     String response = context.response().getOutputAsString();
-    assertTrue(StringUtils.contains(response, "\"" + DummyMediaFormats.EDITORIAL_1COL.getName() + "\""));
-    assertTrue(StringUtils.contains(response, "\"" + DummyMediaFormats.EDITORIAL_2COL.getName() + "\""));
-    assertTrue(StringUtils.contains(response, "\"" + DummyMediaFormats.EDITORIAL_3COL.getName() + "\""));
+
+    DocumentContext json = JsonPath.parse(response);
+    assertThat(json, hasJsonPath("$[*].name", hasItem(DummyMediaFormats.EDITORIAL_1COL.getName())));
+    assertThat(json, hasJsonPath("$[*].name", hasItem(DummyMediaFormats.EDITORIAL_2COL.getName())));
+    assertThat(json, hasJsonPath("$[*].name", hasItem(DummyMediaFormats.EDITORIAL_3COL.getName())));
   }
 
 }


### PR DESCRIPTION
in `DefaultMediaFormatListProvider`, `MediaFormatValidateServlet`

there are some references left in deprecated classes `ResponsiveImageMediaMarkupBuilder`, `DummyResponsiveImageMediaMarkupBuilder` - they can only be removed with breaking backward compatibility, as it's part of the public API