### PR TITLE
MediaHandlerConfig: Change default image quality to 85%

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -40,6 +40,9 @@
         In Media Handler 1.x web renditions (starting with <code>cq5dam.web.</code> prefix) and all other renditions except thumbnails (starting with <code>cq5dam.thumbnail.</code> prefix) were processed.<br/>
         The <code>MediaHandlerConfig</code> contains a new method <code>getIncludeAssetAemRenditionsByDefault</code> that controls this behavior and allows to switch to the previous setting.
       ]]></action>
+      <action type="update" dev="sseifert"><![CDATA[
+        <b>MediaHandlerConfig: Change default image quality for lossy compression image (e.g. JPG) to 85%.</b> In previous versions this was 98%. You can change the default value in the MediaHandlerConfig.
+      ]]></action>
       <action type="update" dev="sseifert" issue="3">
         MediaFileServlet: Force Content-Disposition=attachment header for SVG files served by MediaFileServlet. Also ensure URLs to SVG images are always handled by MediaFileServlet.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -40,7 +40,7 @@
         In Media Handler 1.x web renditions (starting with <code>cq5dam.web.</code> prefix) and all other renditions except thumbnails (starting with <code>cq5dam.thumbnail.</code> prefix) were processed.<br/>
         The <code>MediaHandlerConfig</code> contains a new method <code>getIncludeAssetAemRenditionsByDefault</code> that controls this behavior and allows to switch to the previous setting.
       ]]></action>
-      <action type="update" dev="sseifert"><![CDATA[
+      <action type="update" dev="sseifert" issue="34"><![CDATA[
         <b>MediaHandlerConfig: Change default image quality for lossy compression image (e.g. JPG) to 85%.</b> In previous versions this was 98%. You can change the default value in the MediaHandlerConfig.
       ]]></action>
       <action type="update" dev="sseifert" issue="3">

--- a/src/main/java/io/wcm/handler/media/spi/MediaHandlerConfig.java
+++ b/src/main/java/io/wcm/handler/media/spi/MediaHandlerConfig.java
@@ -50,7 +50,7 @@ public abstract class MediaHandlerConfig implements ContextAwareService {
   /**
    * Default image quality for images with lossy compressions (e.g. JPEG).
    */
-  public static final double DEFAULT_IMAGE_QUALITY = 0.98d;
+  public static final double DEFAULT_IMAGE_QUALITY = 0.85d;
 
   /**
    * Default value for JPEG quality.

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest.java
@@ -49,7 +49,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_JPEG_Original() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia(asset, 100, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?preferwebp=true&quality=98",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?preferwebp=true&quality=85",
         ContentType.JPEG);
   }
 
@@ -67,7 +67,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_JPEG_Rescale() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_Rescale(asset, 80, 40,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?preferwebp=true&quality=98&width=80",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?preferwebp=true&quality=85&width=80",
         ContentType.JPEG);
   }
 
@@ -76,7 +76,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_JPEG_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=98&width=50",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 
@@ -95,7 +95,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     context.create().assetRendition(asset, "square.jpg", 50, 50, ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=98&width=50",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 
@@ -104,7 +104,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_GIF_Original() {
     Asset asset = createSampleAsset("/filetype/sample.gif", ContentType.GIF);
     buildAssertMedia(asset, 100, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.gif?preferwebp=true&quality=98",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.gif?preferwebp=true&quality=85",
         ContentType.GIF);
   }
 
@@ -113,7 +113,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_GIF_Rescale() {
     Asset asset = createSampleAsset("/filetype/sample.gif", ContentType.GIF);
     buildAssertMedia_Rescale(asset, 80, 40,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.gif?preferwebp=true&quality=98&width=80",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.gif?preferwebp=true&quality=85&width=80",
         ContentType.GIF);
   }
 
@@ -122,7 +122,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_GIF_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.gif", ContentType.GIF);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.gif?c=25%2C0%2C50%2C50&preferwebp=true&quality=98&width=50",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.gif?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
         ContentType.GIF);
   }
 
@@ -131,7 +131,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_PNG_Original() {
     Asset asset = createSampleAsset("/filetype/sample.png", ContentType.PNG);
     buildAssertMedia(asset, 100, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.png?preferwebp=true&quality=98",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.png?preferwebp=true&quality=85",
         ContentType.PNG);
   }
 
@@ -140,7 +140,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_PNG_Rescale() {
     Asset asset = createSampleAsset("/filetype/sample.png", ContentType.PNG);
     buildAssertMedia_Rescale(asset, 80, 40,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.png?preferwebp=true&quality=98&width=80",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.png?preferwebp=true&quality=85&width=80",
         ContentType.PNG);
   }
 
@@ -149,7 +149,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_PNG_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.png", ContentType.PNG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.png?c=25%2C0%2C50%2C50&preferwebp=true&quality=98&width=50",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.png?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
         ContentType.PNG);
   }
 
@@ -158,7 +158,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_TIFF_Original() {
     Asset asset = createSampleAsset("/filetype/sample.tif", ContentType.TIFF);
     buildAssertMedia(asset, 100, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?preferwebp=true&quality=98",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?preferwebp=true&quality=85",
         ContentType.JPEG);
   }
 
@@ -167,7 +167,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_TIFF_Rescale() {
     Asset asset = createSampleAsset("/filetype/sample.tif", ContentType.TIFF);
     buildAssertMedia_Rescale(asset, 80, 40,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?preferwebp=true&quality=98&width=80",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?preferwebp=true&quality=85&width=80",
         ContentType.JPEG);
   }
 
@@ -176,7 +176,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_TIFF_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.tif", ContentType.TIFF);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=98&width=50",
+        "/asset/delivery/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 

--- a/src/test/java/io/wcm/handler/mediasource/dam/DamUriTemplateRenditionTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/DamUriTemplateRenditionTest.java
@@ -139,7 +139,7 @@ class DamUriTemplateRenditionTest {
         .build();
 
     assertUriTemplate(media.getRendition(), SCALE_WIDTH, 192, 120,
-        "/asset/delivery/" + assetId + "/sample.jpg?preferwebp=true&quality=98&width={width}");
+        "/asset/delivery/" + assetId + "/sample.jpg?preferwebp=true&quality=85&width={width}");
     assertUriTemplate(media.getRendition(), SCALE_HEIGHT, 192, 120,
         "/content/dam/folder1/sample.jpg/_jcr_content/renditions/original.image_file.0.{height}.file/sample.jpg");
   }
@@ -184,7 +184,7 @@ class DamUriTemplateRenditionTest {
         .build();
 
     assertUriTemplate(media.getRendition(), SCALE_WIDTH, 160, 120,
-        "/asset/delivery/" + assetId + "/sample.jpg?c=16%2C0%2C160%2C120&preferwebp=true&quality=98&width={width}");
+        "/asset/delivery/" + assetId + "/sample.jpg?c=16%2C0%2C160%2C120&preferwebp=true&quality=85&width={width}");
     assertUriTemplate(media.getRendition(), SCALE_HEIGHT, 160, 120,
         "/content/dam/folder1/sample.jpg/_jcr_content/renditions/original.image_file.0.{height}.16,0,176,120.file/sample.jpg");
   }

--- a/src/test/java/io/wcm/handler/mediasource/dam/DamUriTemplateTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/DamUriTemplateTest.java
@@ -111,9 +111,9 @@ class DamUriTemplateTest {
     Media media = mediaHandler.get(asset.getPath()).build();
 
     assertUriTemplate(media, CROP_CENTER, 100, 50,
-        "/asset/delivery/" + assetId + "/sample.jpg?preferwebp=true&quality=98&width={width}");
+        "/asset/delivery/" + assetId + "/sample.jpg?preferwebp=true&quality=85&width={width}");
     assertUriTemplate(media, SCALE_WIDTH, 100, 50,
-        "/asset/delivery/" + assetId + "/sample.jpg?preferwebp=true&quality=98&width={width}");
+        "/asset/delivery/" + assetId + "/sample.jpg?preferwebp=true&quality=85&width={width}");
     assertUriTemplate(media, SCALE_HEIGHT, 100, 50,
         "/content/dam/sample.jpg/_jcr_content/renditions/original.image_file.0.{height}.file/sample.jpg");
   }


### PR DESCRIPTION
MediaHandlerConfig: Change default image quality for lossy compression image (e.g. JPG) to 85%.
In previous versions this was 98%. You can change the default value in the MediaHandlerConfig.