### PR TITLE
Make NextGen Dynamic Media API access compatible with AEM 6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,8 +258,10 @@
             Import-Package: \
               <!-- For build compatibility with Java 11 -->\
               javax.annotation;version="[0.0,2)",\
-              <!-- Package version change between AEM 6.2 and AEM 6.3 -->\
-              com.day.cq.dam.api.handler;version="[1.0,3)",\
+              <!-- Package version newer in AEM 6.5 than in AEMaaCS -->\
+              com.day.cq.dam.api.handler;version="[2.0,3)",\
+              <!-- Package is not accessible in AEM 6.5 -->\
+              com.adobe.cq.ui.wcm.commons.config;resolution:=optional,\
               <!-- Caffeine is embedded -->\
               !com.github.benmanes.caffeine.*,\
               *

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSource.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSource.java
@@ -32,7 +32,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 
-import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
 import com.day.cq.wcm.api.WCMMode;
 import com.day.cq.wcm.api.components.ComponentContext;
 
@@ -44,6 +43,7 @@ import io.wcm.handler.media.MediaRequest;
 import io.wcm.handler.media.markup.MediaMarkupBuilderUtil;
 import io.wcm.handler.media.spi.MediaHandlerConfig;
 import io.wcm.handler.media.spi.MediaSource;
+import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaConfigService;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaContext;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaReference;
 import io.wcm.sling.models.annotations.AemObject;
@@ -67,7 +67,7 @@ public class NextGenDynamicMediaMediaSource extends MediaSource {
   @Self
   private MediaHandlerConfig mediaHandlerConfig;
   @OSGiService(injectionStrategy = InjectionStrategy.OPTIONAL)
-  private NextGenDynamicMediaConfig nextGenDynamicMediaConfig;
+  private NextGenDynamicMediaConfigService nextGenDynamicMediaConfig;
   @OSGiService
   private MimeTypeService mimeTypeService;
 

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigService.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigService.java
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.ngdm.impl;
+
+/**
+ * Service to access Next Generation Dynamic Media configuration.
+ */
+public interface NextGenDynamicMediaConfigService {
+
+  /**
+   * Checks if the configuration/feature is enabled.
+   * @return true if enabled and false otherwise
+   */
+  boolean enabled();
+
+  /**
+   * Gets the path expression for the image delivery path. The following placeholders with the below meaning are
+   * contained within that path:
+   * <ul>
+   * <li><code>{asset-id}</code> - the uuid of the asset in the format 'urn:aaid:aem:UUID', e.g.
+   * urn:aaid:aem:1a034bee-ebda-4787-bad3-f924d0772b75</li>
+   * <li><code>{seo-name}</code> - any url-encoded or alphanumeric, non-whitespace set of characters. may contain
+   * hyphens and
+   * dots</li>
+   * <li><code>{format}</code> - output format</li>
+   * </ul>
+   * @return the path expression for the image delivery path
+   */
+  String getImageDeliveryBasePath();
+
+  /**
+   * Gets the Next Generation Dynamic Media tenant (also known technically as the repository ID).
+   * @return the repository ID
+   */
+  String getRepositoryId();
+
+}

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.ngdm.impl;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
+
+/**
+ * Wraps access to NextGenDynamicMediaConfig - which is deployed but not accessible on AEM 6.5.
+ */
+@Component(service = NextGenDynamicMediaConfigService.class, immediate = true)
+public class NextGenDynamicMediaConfigServiceImpl implements NextGenDynamicMediaConfigService {
+
+  @Reference
+  private NextGenDynamicMediaConfig nextGenDynamicMediaConfig;
+
+  @Override
+  public boolean enabled() {
+    return this.nextGenDynamicMediaConfig.enabled();
+  }
+
+  @Override
+  public String getImageDeliveryBasePath() {
+    return this.nextGenDynamicMediaConfig.getImageDeliveryBasePath();
+  }
+
+  @Override
+  public String getRepositoryId() {
+    return this.nextGenDynamicMediaConfig.getRepositoryId();
+  }
+
+}

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaContext.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaContext.java
@@ -22,8 +22,6 @@ package io.wcm.handler.mediasource.ngdm.impl;
 import org.apache.sling.commons.mime.MimeTypeService;
 import org.jetbrains.annotations.NotNull;
 
-import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
-
 import io.wcm.handler.media.Media;
 import io.wcm.handler.media.MediaArgs;
 import io.wcm.handler.media.spi.MediaHandlerConfig;
@@ -36,7 +34,7 @@ public final class NextGenDynamicMediaContext {
   private final NextGenDynamicMediaReference reference;
   private final Media media;
   private final MediaArgs defaultMediaArgs;
-  private final NextGenDynamicMediaConfig nextGenDynamicMediaConfig;
+  private final NextGenDynamicMediaConfigService nextGenDynamicMediaConfig;
   private final MediaHandlerConfig mediaHandlerConfig;
   private final MimeTypeService mimeTypeService;
 
@@ -50,7 +48,7 @@ public final class NextGenDynamicMediaContext {
   public NextGenDynamicMediaContext(@NotNull NextGenDynamicMediaReference reference,
       @NotNull Media media,
       @NotNull MediaArgs defaultMediaArgs,
-      @NotNull NextGenDynamicMediaConfig nextGenDynamicMediaConfig,
+      @NotNull NextGenDynamicMediaConfigService nextGenDynamicMediaConfig,
       @NotNull MediaHandlerConfig mediaHandlerConfig,
       @NotNull MimeTypeService mimeTypeService) {
     this.reference = reference;
@@ -73,7 +71,7 @@ public final class NextGenDynamicMediaContext {
     return this.defaultMediaArgs;
   }
 
-  public @NotNull NextGenDynamicMediaConfig getNextGenDynamicMediaConfig() {
+  public @NotNull NextGenDynamicMediaConfigService getNextGenDynamicMediaConfig() {
     return this.nextGenDynamicMediaConfig;
   }
 

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.Rendition;
 
+import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaConfigServiceImpl;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaReference;
 import io.wcm.testing.mock.aem.dam.ngdm.MockNextGenDynamicMediaConfig;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -47,6 +48,7 @@ class MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest extends Media
     MockNextGenDynamicMediaConfig nextGenDynamicMediaConfig = context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class);
     nextGenDynamicMediaConfig.setEnabled(true);
     nextGenDynamicMediaConfig.setRepositoryId("repo1");
+    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
     super.setUp();
   }
 

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSourceTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSourceTest.java
@@ -39,6 +39,7 @@ import io.wcm.handler.commons.dom.Image;
 import io.wcm.handler.media.MediaArgs;
 import io.wcm.handler.media.MediaRequest;
 import io.wcm.handler.media.testcontext.AppAemContext;
+import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaConfigServiceImpl;
 import io.wcm.sling.commons.adapter.AdaptTo;
 import io.wcm.testing.mock.aem.dam.ngdm.MockNextGenDynamicMediaConfig;
 import io.wcm.testing.mock.aem.junit5.AemContext;
@@ -121,5 +122,6 @@ class NextGenDynamicMediaMediaSourceTest {
     MockNextGenDynamicMediaConfig nextGenDynamicMediaConfig = context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class);
     nextGenDynamicMediaConfig.setEnabled(enabled);
     nextGenDynamicMediaConfig.setRepositoryId("repo1");
+    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
   }
 }

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaTest.java
@@ -43,6 +43,7 @@ import io.wcm.handler.media.UriTemplate;
 import io.wcm.handler.media.UriTemplateType;
 import io.wcm.handler.media.testcontext.AppAemContext;
 import io.wcm.handler.media.testcontext.DummyMediaFormats;
+import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaConfigServiceImpl;
 import io.wcm.sling.commons.adapter.AdaptTo;
 import io.wcm.testing.mock.aem.dam.ngdm.MockNextGenDynamicMediaConfig;
 import io.wcm.testing.mock.aem.junit5.AemContext;
@@ -63,6 +64,7 @@ class NextGenDynamicMediaTest {
     MockNextGenDynamicMediaConfig nextGenDynamicMediaConfig = context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class);
     nextGenDynamicMediaConfig.setEnabled(true);
     nextGenDynamicMediaConfig.setRepositoryId("repo1");
+    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
 
     resource = context.create().resource(context.currentPage(), "test",
         MediaNameConstants.PN_MEDIA_REF, SAMPLE_REFERENCE);

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaUrlBuilderTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaUrlBuilderTest.java
@@ -41,14 +41,15 @@ class NextGenDynamicMediaUrlBuilderTest {
 
   private final AemContext context = AppAemContext.newAemContext();
 
-  private MockNextGenDynamicMediaConfig nextGenDynamicMediaConfig;
+  private NextGenDynamicMediaConfigService nextGenDynamicMediaConfig;
   private MediaHandlerConfig mediaHandlerConfig;
   private MimeTypeService mimeTypeService;
 
   @BeforeEach
   void setUp() throws Exception {
-    nextGenDynamicMediaConfig = context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class);
-    nextGenDynamicMediaConfig.setRepositoryId("repo1");
+    context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class)
+        .setRepositoryId("repo1");
+    nextGenDynamicMediaConfig = context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
 
     mediaHandlerConfig = AdaptTo.notNull(context.request(), MediaHandlerConfig.class);
     mimeTypeService = context.getService(MimeTypeService.class);


### PR DESCRIPTION
the package `com.adobe.cq.ui.wcm.commons.config` is deployed in AEM 6.5, but not accessible via OSGi API access restrictions. so we need the access to it optional.