### PR TITLE
Next Generation Dynamic Media: Support non-image assets and SVG assets.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="2.0.2" date="not released">
+      <action type="update" dev="sseifert" issue="44">
+        Next Generation Dynamic Media: Support non-image assets and SVG assets.
+      </action>
+    </release>
+
     <release version="2.0.0" date="2024-01-26">
       <action type="update" dev="sseifert"><![CDATA[
         Version 2.0.0 contains minor breaking API changes, see <a href=https://wcm-io.atlassian.net/wiki/x/AYBxsw">Migrate from wcm.io Handler 1.x to 2.x</a> for details.

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaAsset.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaAsset.java
@@ -110,9 +110,6 @@ final class NextGenDynamicMediaAsset implements Asset {
 
   @Override
   public @NotNull UriTemplate getUriTemplate(@NotNull UriTemplateType type) {
-    if (type == UriTemplateType.SCALE_HEIGHT) {
-      throw new IllegalArgumentException("URI template type not supported: " + type);
-    }
     return new NextGenDynamicMediaUriTemplate(context, type);
   }
 

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModel.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModel.java
@@ -29,6 +29,7 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,14 +90,14 @@ public final class NextGenDynamicMediaConfigModel {
   /**
    * @return Asset Selectors URL
    */
-  public String getAssetSelectorsJsUrl() {
+  public @Nullable String getAssetSelectorsJsUrl() {
     return this.assetSelectorsJsUrl;
   }
 
   /**
    * @return JSON string with configuration data required on the client-side.
    */
-  public String getConfigJson() {
+  public @Nullable String getConfigJson() {
     return this.configJson;
   }
 

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModel.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModel.java
@@ -29,6 +29,7 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,8 @@ import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaConfigService;
  * Prepares Next Generation Dynamic Media configuration for GraniteUI components (fileupload, pathfield).
  */
 @Model(adaptables = SlingHttpServletRequest.class)
-public class NextGenDynamicMediaConfigModel {
+@ProviderType
+public final class NextGenDynamicMediaConfigModel {
 
   private static final JsonMapper MAPPER = JsonMapper.builder().build();
   private static final Logger log = LoggerFactory.getLogger(NextGenDynamicMediaConfigModel.class);

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModel.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModel.java
@@ -1,0 +1,101 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.ngdm;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaConfigService;
+
+/**
+ * Prepares Next Generation Dynamic Media configuration for GraniteUI components (fileupload, pathfield).
+ */
+@Model(adaptables = SlingHttpServletRequest.class)
+public class NextGenDynamicMediaConfigModel {
+
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+  private static final Logger log = LoggerFactory.getLogger(NextGenDynamicMediaConfigModel.class);
+
+  @OSGiService(injectionStrategy = InjectionStrategy.OPTIONAL)
+  private NextGenDynamicMediaConfigService config;
+
+  private boolean enabled;
+  private String assetSelectorsJsUrl;
+  private String configJson;
+
+  @PostConstruct
+  private void activate() {
+    if (config != null) {
+      enabled = config.enabled();
+      assetSelectorsJsUrl = config.getAssetSelectorsJsUrl();
+      configJson = buildConfigJsonString(config);
+    }
+  }
+
+  private static String buildConfigJsonString(@NotNull NextGenDynamicMediaConfigService config) {
+    Map<String, Object> map = new TreeMap<>();
+    map.put("repositoryId", config.getRepositoryId());
+    map.put("apiKey", config.getApiKey());
+    map.put("env", config.getEnv());
+    map.put("imsClient", config.getImsClient());
+    try {
+      return MAPPER.writeValueAsString(map);
+    }
+    catch (JsonProcessingException ex) {
+      log.warn("Unable to serialize Next Generation Dynamic Media config to JSON.", ex);
+      return "{}";
+    }
+  }
+
+  /**
+   * @return true if Next Generation Dynamic Media is available and enabled.
+   */
+  public boolean isEnabled() {
+    return this.enabled;
+  }
+
+  /**
+   * @return Asset Selectors URL
+   */
+  public String getAssetSelectorsJsUrl() {
+    return this.assetSelectorsJsUrl;
+  }
+
+  /**
+   * @return JSON string with configuration data required on the client-side.
+   */
+  public String getConfigJson() {
+    return this.configJson;
+  }
+
+}

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSource.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSource.java
@@ -93,7 +93,7 @@ public final class NextGenDynamicMediaMediaSource extends MediaSource {
 
   private boolean isNextGenDynamicMediaEnabled() {
     if (nextGenDynamicMediaConfig == null) {
-      log.debug("NextGenDynamicMediaConfigService not available, NGDM media source is disabled.");
+      log.debug("NGDM media source is disabled: com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig is not available.");
       return false;
     }
     return nextGenDynamicMediaConfig.enabled();

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSource.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSource.java
@@ -31,6 +31,8 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.day.cq.wcm.api.WCMMode;
 import com.day.cq.wcm.api.components.ComponentContext;
@@ -77,6 +79,8 @@ public final class NextGenDynamicMediaMediaSource extends MediaSource {
   @AemObject(injectionStrategy = InjectionStrategy.OPTIONAL)
   private ComponentContext componentContext;
 
+  private static final Logger log = LoggerFactory.getLogger(NextGenDynamicMediaMediaSource.class);
+
   @Override
   public @NotNull String getId() {
     return ID;
@@ -88,7 +92,11 @@ public final class NextGenDynamicMediaMediaSource extends MediaSource {
   }
 
   private boolean isNextGenDynamicMediaEnabled() {
-    return nextGenDynamicMediaConfig != null && nextGenDynamicMediaConfig.enabled();
+    if (nextGenDynamicMediaConfig == null) {
+      log.debug("NextGenDynamicMediaConfigService not available, NGDM media source is disabled.");
+      return false;
+    }
+    return nextGenDynamicMediaConfig.enabled();
   }
 
   @Override

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaUriTemplate.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaUriTemplate.java
@@ -29,7 +29,7 @@ import io.wcm.handler.mediasource.ngdm.impl.ImageQualityPercentage;
 import io.wcm.handler.mediasource.ngdm.impl.MediaArgsDimension;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaContext;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaImageDeliveryParams;
-import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaUrlBuilder;
+import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaImageUrlBuilder;
 
 /**
  * {@link UriTemplate} implementation for Next Gen. Dynamic Media remote assets.
@@ -43,6 +43,10 @@ final class NextGenDynamicMediaUriTemplate implements UriTemplate {
       @NotNull UriTemplateType type) {
     this.type = type;
 
+    if (type == UriTemplateType.SCALE_HEIGHT) {
+      throw new IllegalArgumentException("URI template type not supported: " + type);
+    }
+
     NextGenDynamicMediaImageDeliveryParams params = new NextGenDynamicMediaImageDeliveryParams()
         .widthPlaceholder(MediaNameConstants.URI_TEMPLATE_PLACEHOLDER_WIDTH)
         .rotation(context.getMedia().getRotation())
@@ -53,7 +57,7 @@ final class NextGenDynamicMediaUriTemplate implements UriTemplate {
       params.cropSmartRatio(ratio);
     }
 
-    this.uriTemplate = new NextGenDynamicMediaUrlBuilder(context).build(params);
+    this.uriTemplate = new NextGenDynamicMediaImageUrlBuilder(context).build(params);
   }
 
   @Override

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaBinaryUrlBuilder.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaBinaryUrlBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.ngdm.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Builds URL to reference a binary file via NextGen Dynamic Media.
+ * <p>
+ * Example URL that might be build:
+ * https://host/adobe/assets/deliver/urn:aaid:aem:12345678-abcd-abcd-abcd-abcd12345678/my-file.pdf
+ * </p>
+ */
+public final class NextGenDynamicMediaBinaryUrlBuilder {
+
+  static final String PLACEHOLDER_ASSET_ID = "{asset-id}";
+  static final String PLACEHOLDER_SEO_NAME = "{seo-name}";
+
+  private final NextGenDynamicMediaContext context;
+
+  /**
+   * @param context Context
+   */
+  public NextGenDynamicMediaBinaryUrlBuilder(@NotNull NextGenDynamicMediaContext context) {
+    this.context = context;
+  }
+
+  /**
+   * Builds the URL for a rendition.
+   * @return URL or null if invalid/not possible
+   */
+  public @Nullable String build() {
+
+    // get parameters from nextgen dynamic media config for URL parameters
+    String repositoryId = context.getNextGenDynamicMediaConfig().getRepositoryId();
+    String binaryDeliveryPath = context.getNextGenDynamicMediaConfig().getAssetOriginalBinaryDeliveryPath();
+    if (StringUtils.isAnyEmpty(repositoryId, binaryDeliveryPath)) {
+      return null;
+    }
+
+    // replace placeholders in image delivery path
+    String seoName = context.getReference().getFileName();
+    binaryDeliveryPath = StringUtils.replace(binaryDeliveryPath, PLACEHOLDER_ASSET_ID, context.getReference().getAssetId());
+    binaryDeliveryPath = StringUtils.replace(binaryDeliveryPath, PLACEHOLDER_SEO_NAME, seoName);
+
+    // build URL
+    StringBuilder url = new StringBuilder();
+    url.append("https://")
+        .append(repositoryId)
+        .append(binaryDeliveryPath);
+    return url.toString();
+  }
+
+}

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigService.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigService.java
@@ -51,4 +51,22 @@ public interface NextGenDynamicMediaConfigService {
    */
   String getRepositoryId();
 
+  /**
+   * Gets the API key for accessing the asset selectors UI
+   * @return the API key for accessing the asset selectors UI
+   */
+  String getApiKey();
+
+  /**
+   * Gets the environment string which should be 'PROD' or 'STAGE'
+   * @return the environment string
+   */
+  String getEnv();
+
+  /**
+   * Gets the IMS client identifier
+   * @return the IMS client identifier
+   */
+  String getImsClient();
+
 }

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigService.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigService.java
@@ -31,6 +31,12 @@ public interface NextGenDynamicMediaConfigService {
   boolean enabled();
 
   /**
+   * Gets the absolute URL for the javascript which contains the microfrontend for the remote asset selector.
+   * @return the absolute URL for the javascript which contains the microfrontend for the remote asset selector
+   */
+  String getAssetSelectorsJsUrl();
+
+  /**
    * Gets the path expression for the image delivery path. The following placeholders with the below meaning are
    * contained within that path:
    * <ul>
@@ -44,6 +50,45 @@ public interface NextGenDynamicMediaConfigService {
    * @return the path expression for the image delivery path
    */
   String getImageDeliveryBasePath();
+
+  /**
+   * Gets the path expression for the adaptive video manifest/player path. The
+   * following placeholders with the below meaning are contained
+   * within that path:
+   * <ul>
+   * <li><code>{asset-id}</code> - the uuid of the asset in the format 'urn:aaid:aem:UUID'
+   * along with optional format
+   * e.g. urn:aaid:aem:1a034bee-ebda-4787-bad3-f924d0772b75 OR
+   * urn:aaid:aem:1a034bee-ebda-4787-bad3-f924d0772b75.mp4</li>
+   * </ul>
+   * @return the path expression for the video delivery path
+   */
+  String getVideoDeliveryPath();
+
+  /**
+   * Gets the path expression for the the Original Asset Delivery which delivers
+   * the bitstream as-is
+   * <ul>
+   * <li><code>{asset-id}</code> - the uuid of the asset in the format 'urn:aaid:aem:UUID',
+   * e.g. urn:aaid:aem:1a034bee-ebda-4787-bad3-f924d0772b75</li>
+   * <li><code>{seo-name}</code> - any url-encoded or alphanumeric, non-whitespace set of
+   * characters. may contain hyphens and dots</li>
+   * </ul>
+   * @return the path expression for the asset (bitstream) delivery path
+   */
+  String getAssetOriginalBinaryDeliveryPath();
+
+  /**
+   * Gets the path expression for getting the metadata of an asset. The following
+   * placeholders with the below meaning are contained within
+   * that path:
+   * <ul>
+   * <li><code>{asset-id}</code> - the uuid of the asset in the format 'urn:aaid:aem:UUID',
+   * e.g. urn:aaid:aem:1a034bee-ebda-4787-bad3-f924d0772b75</li>
+   * </ul>
+   * @return the path expression for the metadata path
+   */
+  String getAssetMetadataPath();
 
   /**
    * Gets the Next Generation Dynamic Media tenant (also known technically as the repository ID).

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
@@ -48,4 +48,19 @@ public class NextGenDynamicMediaConfigServiceImpl implements NextGenDynamicMedia
     return this.nextGenDynamicMediaConfig.getRepositoryId();
   }
 
+  @Override
+  public String getApiKey() {
+    return this.nextGenDynamicMediaConfig.getApiKey();
+  }
+
+  @Override
+  public String getEnv() {
+    return this.nextGenDynamicMediaConfig.getEnv();
+  }
+
+  @Override
+  public String getImsClient() {
+    return this.nextGenDynamicMediaConfig.getImsClient();
+  }
+
 }

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
@@ -22,6 +22,8 @@ package io.wcm.handler.mediasource.ngdm.impl;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +37,7 @@ public class NextGenDynamicMediaConfigServiceImpl implements NextGenDynamicMedia
 
   private static final Logger log = LoggerFactory.getLogger(NextGenDynamicMediaConfigServiceImpl.class);
 
-  @Reference
+  @Reference(policy = ReferencePolicy.STATIC, policyOption = ReferencePolicyOption.GREEDY)
   private NextGenDynamicMediaConfig nextGenDynamicMediaConfig;
 
   @Activate

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
@@ -39,8 +39,28 @@ public class NextGenDynamicMediaConfigServiceImpl implements NextGenDynamicMedia
   }
 
   @Override
+  public String getAssetSelectorsJsUrl() {
+    return this.nextGenDynamicMediaConfig.getAssetSelectorsJsUrl();
+  }
+
+  @Override
   public String getImageDeliveryBasePath() {
     return this.nextGenDynamicMediaConfig.getImageDeliveryBasePath();
+  }
+
+  @Override
+  public String getVideoDeliveryPath() {
+    return this.nextGenDynamicMediaConfig.getVideoDeliveryPath();
+  }
+
+  @Override
+  public String getAssetOriginalBinaryDeliveryPath() {
+    return this.nextGenDynamicMediaConfig.getAssetOriginalBinaryDeliveryPath();
+  }
+
+  @Override
+  public String getAssetMetadataPath() {
+    return this.nextGenDynamicMediaConfig.getAssetMetadataPath();
   }
 
   @Override

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
@@ -19,8 +19,11 @@
  */
 package io.wcm.handler.mediasource.ngdm.impl;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
 
@@ -30,8 +33,16 @@ import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
 @Component(service = NextGenDynamicMediaConfigService.class, immediate = true)
 public class NextGenDynamicMediaConfigServiceImpl implements NextGenDynamicMediaConfigService {
 
+  private static final Logger log = LoggerFactory.getLogger(NextGenDynamicMediaConfigServiceImpl.class);
+
   @Reference
   private NextGenDynamicMediaConfig nextGenDynamicMediaConfig;
+
+  @Activate
+  private void activate() {
+    log.debug("NGDM config: enabled={}, repositoryId={}, apiKey={}, env={}, imsClient={}",
+        enabled(), getRepositoryId(), getApiKey(), getEnv(), getImsClient());
+  }
 
   @Override
   public boolean enabled() {

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaImageUrlBuilder.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaImageUrlBuilder.java
@@ -41,7 +41,7 @@ import io.wcm.wcm.commons.contenttype.FileExtension;
  * https://host/adobe/dynamicmedia/deliver/urn:aaid:aem:12345678-abcd-abcd-abcd-abcd12345678/my-image.jpg?preferwebp=true&quality=85&width=300&crop=16:9,smart
  * </p>
  */
-public final class NextGenDynamicMediaUrlBuilder {
+public final class NextGenDynamicMediaImageUrlBuilder {
 
   static final String PLACEHOLDER_ASSET_ID = "{asset-id}";
   static final String PLACEHOLDER_SEO_NAME = "{seo-name}";
@@ -64,7 +64,7 @@ public final class NextGenDynamicMediaUrlBuilder {
   /**
    * @param context Context
    */
-  public NextGenDynamicMediaUrlBuilder(@NotNull NextGenDynamicMediaContext context) {
+  public NextGenDynamicMediaImageUrlBuilder(@NotNull NextGenDynamicMediaContext context) {
     this.context = context;
   }
 

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/package-info.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Media source implementation for Next Generation Dynamic Media.
  */
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.handler.mediasource.ngdm;

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/css.txt
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/css.txt
@@ -1,2 +1,3 @@
 #base=css
 fileupload.less
+nextGenDynamicMedia.less

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/css/nextGenDynamicMedia.less
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/css/nextGenDynamicMedia.less
@@ -1,0 +1,5 @@
+.wcmio-handler-media-ngdm-assetselector-dialogbody {
+  width: 80vw;
+  height: 80vh;
+  padding-bottom: 5px;
+}

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js.txt
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js.txt
@@ -1,6 +1,7 @@
 #base=js
 namespace.js
 mediaFormatValidate.js
+nextGenDynamicMedia.js
 fileupload.js
 pathfield.js
 validation.js

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js/fileupload.js
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js/fileupload.js
@@ -32,7 +32,10 @@
 
     // enable nextgen dynamic media
     self._validate = new ns.NextGenDynamicMedia({
-      pathfield: self._pathfield
+      pathfield: self._pathfield,
+      assetSelectedCallback: (assetReference) => {
+        self._triggerAssetSelected(assetReference);
+      }
     });
 
     // enable asset validation

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js/fileupload.js
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js/fileupload.js
@@ -30,6 +30,24 @@
     self._addClearTransformationButton();
     self._updatePickLink();
 
+
+    var buttonWrapper = document.createElement("span");
+    buttonWrapper.classList.add("coral-InputGroup-button");
+    var newButton = new Coral.Button().set({
+      icon: "popOut",
+      title: "Pick Remote",
+      type: "button"
+    });
+    newButton.setAttribute("aria-label", "Pick Remote");
+    buttonWrapper.appendChild(newButton);
+    var $newButton = $(newButton);
+    $newButton.on("click", function(e) {
+      alert('pick remote asset...');
+    });
+    var $existingButtonWrapper = self._$pathfield.find(".coral-InputGroup-button");
+    $(buttonWrapper).insertAfter($existingButtonWrapper);
+
+
     // enable asset validation
     self._validate = new ns.MediaFormatValidate({
       pathfield: self._pathfield

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js/fileupload.js
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js/fileupload.js
@@ -30,23 +30,10 @@
     self._addClearTransformationButton();
     self._updatePickLink();
 
-
-    var buttonWrapper = document.createElement("span");
-    buttonWrapper.classList.add("coral-InputGroup-button");
-    var newButton = new Coral.Button().set({
-      icon: "popOut",
-      title: "Pick Remote",
-      type: "button"
+    // enable nextgen dynamic media
+    self._validate = new ns.NextGenDynamicMedia({
+      pathfield: self._pathfield
     });
-    newButton.setAttribute("aria-label", "Pick Remote");
-    buttonWrapper.appendChild(newButton);
-    var $newButton = $(newButton);
-    $newButton.on("click", function(e) {
-      alert('pick remote asset...');
-    });
-    var $existingButtonWrapper = self._$pathfield.find(".coral-InputGroup-button");
-    $(buttonWrapper).insertAfter($existingButtonWrapper);
-
 
     // enable asset validation
     self._validate = new ns.MediaFormatValidate({

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js/nextGenDynamicMedia.js
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js/nextGenDynamicMedia.js
@@ -98,7 +98,7 @@
         $underlay.removeClass("is-open");
         assetSelectorDialog.remove();
       },
-      hideTreeNav: false,
+      hideTreeNav: true,
       acvConfig: {
         selectionType: "single",
       },

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js/nextGenDynamicMedia.js
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js/nextGenDynamicMedia.js
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+;(function ($, ns, channel, document, window, undefined) {
+  "use strict";
+
+  var NextGenDynamicMedia = function (config) {
+    var self = this;
+    self._pathfield = config.pathfield;
+    self._$pathfield = $(config.pathfield);
+    self._config = self._$pathfield.data("wcmio-nextgendynamicmedia-config");
+
+    if (!self._config) {
+      // NGDM not enabled
+      return;
+    }
+
+    self._addPickRemoteButton();
+  };
+
+  /**
+   * Add additional button to pathfield to pick remote assets.
+   */
+  NextGenDynamicMedia.prototype._addPickRemoteButton = function () {
+    var self = this;
+
+    var label = Granite.I18n.get("Remote");
+    var pickRemoteButton = new Coral.Button().set({
+      icon: "popOut",
+      title: label,
+      type: "button"
+    });
+    pickRemoteButton.setAttribute("aria-label", label);
+    $(pickRemoteButton).on("click", function() {
+      self.pickRemoteAsset();
+    });
+
+    var buttonWrapper = document.createElement("span");
+    buttonWrapper.classList.add("coral-InputGroup-button");
+    buttonWrapper.appendChild(pickRemoteButton);
+
+    // add new button (wrapper) after existing one to pick local assets
+    $(buttonWrapper).insertAfter(self._$pathfield.find(".coral-InputGroup-button"));
+  }
+
+  /**
+   * Opens NGDM asset selector to pick a remote asset.
+   */
+  NextGenDynamicMedia.prototype.pickRemoteAsset = function () {
+    var self = this;
+
+    alert(`pick remote asset: ${JSON.stringify(self._config)}`);
+  }
+
+  ns.NextGenDynamicMedia = NextGenDynamicMedia;
+
+}(Granite.$, wcmio.handler.media, jQuery(document), document, this));

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js/pathfield.js
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js/pathfield.js
@@ -26,6 +26,11 @@
     self._$pathfield = $(config.pathfield);
     self._bindEvents();
 
+    // enable nextgen dynamic media
+    self._validate = new ns.NextGenDynamicMedia({
+      pathfield: self._pathfield
+    });
+
     // enable asset validation
     self._validate = new ns.MediaFormatValidate({
       pathfield: self._pathfield

--- a/src/main/webapp/app-root/components/granite/form/fileupload/fileupload.jsp
+++ b/src/main/webapp/app-root/components/granite/form/fileupload/fileupload.jsp
@@ -29,6 +29,7 @@
 <%@page import="com.adobe.granite.ui.components.ExpressionHelper"%>
 <%@page import="io.wcm.handler.media.MediaNameConstants"%>
 <%@page import="io.wcm.handler.media.MediaComponentPropertyResolver"%>
+<%@page import="io.wcm.handler.mediasource.ngdm.NextGenDynamicMediaConfigModel"%>
 <%@page import="io.wcm.handler.media.spi.MediaHandlerConfig"%>
 <%@page import="io.wcm.wcm.ui.granite.resource.GraniteUiSyntheticResource"%>
 <%@page import="io.wcm.wcm.ui.granite.util.GraniteUi"%>
@@ -225,6 +226,12 @@ if (hasTransformation) {
 }
 if (!dataProps.isEmpty()) {
   GraniteUiSyntheticResource.child(pathField, "granite:data", null, new ValueMapDecorator(dataProps));
+}
+
+// NGDM config (if enabled)
+NextGenDynamicMediaConfigModel nextGenDynamicMediaConfig = slingRequest.adaptTo(NextGenDynamicMediaConfigModel.class);
+if (nextGenDynamicMediaConfig.isEnabled()) {
+  dataProps.put("wcmio-nextgendynamicmedia-config", nextGenDynamicMediaConfig.getConfigJson());
 }
 
 dispatcher = slingRequest.getRequestDispatcher(pathField);

--- a/src/main/webapp/app-root/components/granite/form/pathfield/pathfield.jsp
+++ b/src/main/webapp/app-root/components/granite/form/pathfield/pathfield.jsp
@@ -29,6 +29,7 @@
 <%@page import="com.adobe.granite.ui.components.ExpressionHelper"%>
 <%@page import="io.wcm.handler.media.MediaNameConstants"%>
 <%@page import="io.wcm.handler.media.MediaComponentPropertyResolver"%>
+<%@page import="io.wcm.handler.mediasource.ngdm.NextGenDynamicMediaConfigModel"%>
 <%@page import="io.wcm.handler.media.spi.MediaHandlerConfig"%>
 <%@page import="io.wcm.wcm.ui.granite.resource.GraniteUiSyntheticResource"%>
 <%@page import="io.wcm.wcm.ui.granite.util.GraniteUi"%>
@@ -169,6 +170,12 @@ if (mediaFormats != null && mediaFormats.length > 0) {
 }
 if (!dataProps.isEmpty()) {
   GraniteUiSyntheticResource.child(pathField, "granite:data", null, new ValueMapDecorator(dataProps));
+}
+
+// NGDM config (if enabled)
+NextGenDynamicMediaConfigModel nextGenDynamicMediaConfig = slingRequest.adaptTo(NextGenDynamicMediaConfigModel.class);
+if (nextGenDynamicMediaConfig.isEnabled()) {
+  dataProps.put("wcmio-nextgendynamicmedia-config", nextGenDynamicMediaConfig.getConfigJson());
 }
 
 // render original component

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest.java
@@ -63,6 +63,15 @@ class MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest extends Media
 
   @Override
   @Test
+  void testAsset_JPEG_Original_ContentDisposition() {
+    Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.jpg");
+    buildAssertMedia_ContentDisposition(asset, 100, 50,
+        "https://repo1/adobe/dynamicmedia/deliver/" + SAMPLE_ASSET_ID + "/sample.jpg?preferwebp=true&quality=85",
+        ContentType.JPEG);
+  }
+
+  @Override
+  @Test
   void testAsset_JPEG_Rescale() {
     Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.jpg");
     buildAssertMedia_Rescale(asset, 80, 40,
@@ -153,6 +162,15 @@ class MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest extends Media
 
   @Override
   @Test
+  void testAsset_TIFF_Original_ContentDisposition() {
+    Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.tif");
+    buildAssertMedia_ContentDisposition(asset, 100, 50,
+        "https://repo1/adobe/dynamicmedia/deliver/" + SAMPLE_ASSET_ID + "/sample.jpg?preferwebp=true&quality=85",
+        ContentType.TIFF);
+  }
+
+  @Override
+  @Test
   void testAsset_TIFF_Rescale() {
     Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.tif");
     buildAssertMedia_Rescale(asset, 80, 40,
@@ -166,6 +184,42 @@ class MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest extends Media
     Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.tif");
     buildAssertMedia_AutoCrop(asset, 50, 50,
         "https://repo1/adobe/dynamicmedia/deliver/" + SAMPLE_ASSET_ID + "/sample.jpg?crop=1%3A1%2Csmart&preferwebp=true&quality=85",
+        ContentType.JPEG);
+  }
+
+  @Override
+  @Test
+  void testAsset_SVG_Original() {
+    Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.svg");
+    buildAssertMedia(asset, 0, 0,
+        "https://repo1/adobe/assets/deliver/" + SAMPLE_ASSET_ID + "/sample.svg",
+        ContentType.SVG);
+  }
+
+  @Override
+  @Test
+  void testAsset_SVG_Original_ContentDisposition() {
+    Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.svg");
+    buildAssertMedia_ContentDisposition(asset, 0, 0,
+        "https://repo1/adobe/assets/deliver/" + SAMPLE_ASSET_ID + "/sample.svg",
+        ContentType.SVG);
+  }
+
+  @Override
+  @Test
+  void testAsset_SVG_Rescale() {
+    Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.svg");
+    buildAssertMedia_Rescale(asset, 0, 0,
+        "https://repo1/adobe/assets/deliver/" + SAMPLE_ASSET_ID + "/sample.svg",
+        ContentType.SVG);
+  }
+
+  @Override
+  @Test
+  void testAsset_SVG_AutoCrop() {
+    Asset asset = createNextGenDynamicMediaReferenceAsAsset("sample.svg");
+    buildAssertMedia_AutoCrop(asset, 0, 0,
+        "https://repo1/adobe/assets/deliver/" + SAMPLE_ASSET_ID + "/sample.svg",
         ContentType.JPEG);
   }
 

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModelTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModelTest.java
@@ -17,55 +17,59 @@
  * limitations under the License.
  * #L%
  */
-package io.wcm.handler.mediasource.ngdm.impl;
+package io.wcm.handler.mediasource.ngdm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import io.wcm.handler.media.testcontext.AppAemContext;
+import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaConfigServiceImpl;
+import io.wcm.sling.commons.adapter.AdaptTo;
 import io.wcm.testing.mock.aem.dam.ngdm.MockNextGenDynamicMediaConfig;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 @ExtendWith(AemContextExtension.class)
-class NextGenDynamicMediaConfigServiceImplTest {
+class NextGenDynamicMediaConfigModelTest {
 
   private final AemContext context = AppAemContext.newAemContext();
-
-  private NextGenDynamicMediaConfigService underTest;
 
   @BeforeEach
   void setUp() {
     MockNextGenDynamicMediaConfig config = context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class);
     config.setEnabled(true);
     config.setAssetSelectorsJsUrl("/selector1");
-    config.setImageDeliveryBasePath("/imagepath1");
-    config.setVideoDeliveryPath("/videopath1");
-    config.setAssetOriginalBinaryDeliveryPath("/assetpath1");
-    config.setAssetMetadataPath("/metadatapath1");
     config.setRepositoryId("repo1");
     config.setApiKey("key1");
     config.setEnv("env1");
     config.setImsClient("client1");
-    underTest = context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
   }
 
   @Test
-  void testProperties() {
-    assertTrue(underTest.enabled());
+  void testWithConfigService() throws JSONException {
+    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
+
+    NextGenDynamicMediaConfigModel underTest = AdaptTo.notNull(context.request(), NextGenDynamicMediaConfigModel.class);
+    assertTrue(underTest.isEnabled());
     assertEquals("/selector1", underTest.getAssetSelectorsJsUrl());
-    assertEquals("/imagepath1", underTest.getImageDeliveryBasePath());
-    assertEquals("/videopath1", underTest.getVideoDeliveryPath());
-    assertEquals("/assetpath1", underTest.getAssetOriginalBinaryDeliveryPath());
-    assertEquals("/metadatapath1", underTest.getAssetMetadataPath());
-    assertEquals("repo1", underTest.getRepositoryId());
-    assertEquals("key1", underTest.getApiKey());
-    assertEquals("env1", underTest.getEnv());
-    assertEquals("client1", underTest.getImsClient());
+    JSONAssert.assertEquals("{repositoryId:'repo1',apiKey:'key1',env:'env1',imsClient:'client1'}",
+        underTest.getConfigJson(), true);
+  }
+
+  @Test
+  void testWithoutConfigService() {
+    NextGenDynamicMediaConfigModel underTest = AdaptTo.notNull(context.request(), NextGenDynamicMediaConfigModel.class);
+    assertFalse(underTest.isEnabled());
+    assertNull(underTest.getAssetSelectorsJsUrl());
+    assertNull(underTest.getConfigJson());
   }
 
 }

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.mediasource.ngdm;
 
+import static io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaReferenceSample.SAMPLE_ASSET_ID;
 import static io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaReferenceSample.SAMPLE_FILENAME;
 import static io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaReferenceSample.SAMPLE_REFERENCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -195,6 +196,22 @@ class NextGenDynamicMediaTest {
     Rendition rendition = media.getRendition();
     assertNotNull(rendition);
     assertUrl(rendition, "preferwebp=true&quality=85", "jpg");
+  }
+
+  @Test
+  @SuppressWarnings("null")
+  void testPDFDownload() {
+    Resource downloadResource = context.create().resource(context.currentPage(), "download",
+        MediaNameConstants.PN_MEDIA_REF, "/" + SAMPLE_ASSET_ID + "/myfile.pdf");
+
+    Media media = mediaHandler.get(downloadResource)
+        .args(new MediaArgs().download(true))
+        .build();
+    assertTrue(media.isValid());
+
+    Rendition rendition = media.getRendition();
+    assertNotNull(rendition);
+    assertEquals("https://repo1/adobe/assets/deliver/" + SAMPLE_ASSET_ID + "/myfile.pdf", rendition.getUrl());
   }
 
   private static void assertUrl(Media media, String urlParams, String extension) {

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaBinaryUrlBuilderTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaBinaryUrlBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.ngdm.impl;
+
+import static io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaReferenceSample.SAMPLE_REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.sling.commons.mime.MimeTypeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.wcm.handler.media.MediaArgs;
+import io.wcm.handler.media.spi.MediaHandlerConfig;
+import io.wcm.handler.media.testcontext.AppAemContext;
+import io.wcm.sling.commons.adapter.AdaptTo;
+import io.wcm.testing.mock.aem.dam.ngdm.MockNextGenDynamicMediaConfig;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(AemContextExtension.class)
+class NextGenDynamicMediaBinaryUrlBuilderTest {
+
+  private final AemContext context = AppAemContext.newAemContext();
+
+  private NextGenDynamicMediaConfigService nextGenDynamicMediaConfig;
+  private MediaHandlerConfig mediaHandlerConfig;
+  private MimeTypeService mimeTypeService;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class)
+        .setRepositoryId("repo1");
+    nextGenDynamicMediaConfig = context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
+
+    mediaHandlerConfig = AdaptTo.notNull(context.request(), MediaHandlerConfig.class);
+    mimeTypeService = context.getService(MimeTypeService.class);
+  }
+
+  @Test
+  void testBuild() {
+    NextGenDynamicMediaBinaryUrlBuilder underTest = getBuilder(new MediaArgs());
+
+    assertEquals("https://repo1/adobe/assets/deliver/urn:aaid:aem:12345678-abcd-abcd-abcd-abcd12345678/my-image.jpg",
+        underTest.build());
+  }
+
+  @SuppressWarnings("null")
+  private NextGenDynamicMediaBinaryUrlBuilder getBuilder(MediaArgs mediaArgs) {
+    NextGenDynamicMediaContext ctx = new NextGenDynamicMediaContext(
+        NextGenDynamicMediaReference.fromReference(SAMPLE_REFERENCE),
+        null,
+        mediaArgs,
+        nextGenDynamicMediaConfig,
+        mediaHandlerConfig,
+        mimeTypeService);
+    return new NextGenDynamicMediaBinaryUrlBuilder(ctx);
+  }
+
+}

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImplTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImplTest.java
@@ -1,0 +1,63 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.ngdm.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.wcm.handler.media.testcontext.AppAemContext;
+import io.wcm.testing.mock.aem.dam.ngdm.MockNextGenDynamicMediaConfig;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(AemContextExtension.class)
+class NextGenDynamicMediaConfigServiceImplTest {
+
+  private final AemContext context = AppAemContext.newAemContext();
+
+  private NextGenDynamicMediaConfigService underTest;
+
+  @BeforeEach
+  void setUp() {
+    MockNextGenDynamicMediaConfig config = context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class);
+    config.setEnabled(true);
+    config.setImageDeliveryBasePath("/path1");
+    config.setRepositoryId("repo1");
+    config.setApiKey("key1");
+    config.setEnv("env1");
+    config.setImsClient("client1");
+    underTest = context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
+  }
+
+  @Test
+  void testProperties() {
+    assertTrue(underTest.enabled());
+    assertEquals("/path1", underTest.getImageDeliveryBasePath());
+    assertEquals("repo1", underTest.getRepositoryId());
+    assertEquals("key1", underTest.getApiKey());
+    assertEquals("env1", underTest.getEnv());
+    assertEquals("client1", underTest.getImsClient());
+  }
+
+}

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaImageUrlBuilderTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaImageUrlBuilderTest.java
@@ -37,7 +37,7 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 @ExtendWith(AemContextExtension.class)
-class NextGenDynamicMediaUrlBuilderTest {
+class NextGenDynamicMediaImageUrlBuilderTest {
 
   private final AemContext context = AppAemContext.newAemContext();
 
@@ -57,7 +57,7 @@ class NextGenDynamicMediaUrlBuilderTest {
 
   @Test
   void testDefaultParams() {
-    NextGenDynamicMediaUrlBuilder underTest = getBuilder();
+    NextGenDynamicMediaImageUrlBuilder underTest = getBuilder();
     NextGenDynamicMediaImageDeliveryParams params = new NextGenDynamicMediaImageDeliveryParams();
 
     assertEquals("https://repo1/adobe/dynamicmedia/deliver/urn:aaid:aem:12345678-abcd-abcd-abcd-abcd12345678/my-image.jpg"
@@ -67,7 +67,7 @@ class NextGenDynamicMediaUrlBuilderTest {
 
   @Test
   void testForceOutputExtension() {
-    NextGenDynamicMediaUrlBuilder underTest = getBuilder(new MediaArgs().enforceOutputFileExtension("png"));
+    NextGenDynamicMediaImageUrlBuilder underTest = getBuilder(new MediaArgs().enforceOutputFileExtension("png"));
     NextGenDynamicMediaImageDeliveryParams params = new NextGenDynamicMediaImageDeliveryParams();
 
     assertEquals("https://repo1/adobe/dynamicmedia/deliver/urn:aaid:aem:12345678-abcd-abcd-abcd-abcd12345678/my-image.png"
@@ -77,7 +77,7 @@ class NextGenDynamicMediaUrlBuilderTest {
 
   @Test
   void testAllParams() {
-    NextGenDynamicMediaUrlBuilder underTest = getBuilder();
+    NextGenDynamicMediaImageUrlBuilder underTest = getBuilder();
     NextGenDynamicMediaImageDeliveryParams params = new NextGenDynamicMediaImageDeliveryParams()
         .width(100L)
         .cropSmartRatio(new Dimension(16, 9))
@@ -91,7 +91,7 @@ class NextGenDynamicMediaUrlBuilderTest {
 
   @Test
   void testWidthPlaceholder() {
-    NextGenDynamicMediaUrlBuilder underTest = getBuilder();
+    NextGenDynamicMediaImageUrlBuilder underTest = getBuilder();
     NextGenDynamicMediaImageDeliveryParams params = new NextGenDynamicMediaImageDeliveryParams()
         .widthPlaceholder("{w}")
         .quality(60);
@@ -101,12 +101,12 @@ class NextGenDynamicMediaUrlBuilderTest {
         underTest.build(params));
   }
 
-  private NextGenDynamicMediaUrlBuilder getBuilder() {
+  private NextGenDynamicMediaImageUrlBuilder getBuilder() {
     return getBuilder(new MediaArgs());
   }
 
   @SuppressWarnings("null")
-  private NextGenDynamicMediaUrlBuilder getBuilder(MediaArgs mediaArgs) {
+  private NextGenDynamicMediaImageUrlBuilder getBuilder(MediaArgs mediaArgs) {
     NextGenDynamicMediaContext ctx = new NextGenDynamicMediaContext(
         NextGenDynamicMediaReference.fromReference(SAMPLE_REFERENCE),
         null,
@@ -114,7 +114,7 @@ class NextGenDynamicMediaUrlBuilderTest {
         nextGenDynamicMediaConfig,
         mediaHandlerConfig,
         mimeTypeService);
-    return new NextGenDynamicMediaUrlBuilder(ctx);
+    return new NextGenDynamicMediaImageUrlBuilder(ctx);
   }
 
 }


### PR DESCRIPTION
directly integrate a button in wcm.io media handler pathfield to open a custom asset selector
https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/assets/manage/asset-selector.html?lang=en
and use binary delivery URLs for SVGs and non-image assets