### PR TITLE
Prevent XSS in SVG with malicious script: Use Content-Security-Policy instead of Content-Disposition header

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,13 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="2.0.6" date="not released">
+      <action type="fix" dev="sseifert" issue="50">
+        MediaFileServlet: Use Content-Security-Policy instead of Content-Disposition header to prevent XSS attacks in SVG files.
+        Make this behavior configurable via OSGi configuration, as it may prevent special use cases e.g. SVGs animatd via JavaScript.
+      </action>
+    </release>
+
     <release version="2.0.4" date="2024-04-17">
       <action type="fix" dev="sseifert" issue="49">
         Fix failing to resolve media when enforceVirtualRenditions is enabled and auto cropping is used at the same time.

--- a/src/main/java/io/wcm/handler/media/impl/AbstractMediaFileServlet.java
+++ b/src/main/java/io/wcm/handler/media/impl/AbstractMediaFileServlet.java
@@ -161,7 +161,7 @@ abstract class AbstractMediaFileServlet extends SlingSafeMethodsServlet {
 
     // special handling for SVG images which are not treated as download:
     // set content security policy to prevent stored XSS attack with malicious JavaScript in SVG file
-    else if (StringUtils.equals(contentType, ContentType.SVG)) {
+    if (StringUtils.equals(contentType, ContentType.SVG)) {
       setSVGContentSecurityPolicy(response);
     }
 
@@ -182,7 +182,7 @@ abstract class AbstractMediaFileServlet extends SlingSafeMethodsServlet {
     response.setHeader(HEADER_CONTENT_DISPOSITION, dispositionHeader.toString());
   }
 
-  private void setSVGContentSecurityPolicy(@NotNull SlingHttpServletResponse response) {
+  protected void setSVGContentSecurityPolicy(@NotNull SlingHttpServletResponse response) {
     response.setHeader(HEADER_CONTENT_SECURITY_POLICY, "sandbox");
   }
 

--- a/src/main/java/io/wcm/handler/media/impl/AbstractMediaFileServlet.java
+++ b/src/main/java/io/wcm/handler/media/impl/AbstractMediaFileServlet.java
@@ -20,6 +20,7 @@
 package io.wcm.handler.media.impl;
 
 import static io.wcm.handler.media.impl.MediaFileServletConstants.HEADER_CONTENT_DISPOSITION;
+import static io.wcm.handler.media.impl.MediaFileServletConstants.HEADER_CONTENT_SECURITY_POLICY;
 import static io.wcm.handler.media.impl.MediaFileServletConstants.SELECTOR_DOWNLOAD;
 
 import java.io.IOException;
@@ -159,9 +160,9 @@ abstract class AbstractMediaFileServlet extends SlingSafeMethodsServlet {
     }
 
     // special handling for SVG images which are not treated as download:
-    // force content disposition header to prevent stored XSS attack with malicious JavaScript in SVG file
+    // set content security policy to prevent stored XSS attack with malicious JavaScript in SVG file
     else if (StringUtils.equals(contentType, ContentType.SVG)) {
-      setContentDispositionAttachmentHeader(request, response);
+      setSVGContentSecurityPolicy(response);
     }
 
     // write binary data
@@ -179,6 +180,10 @@ abstract class AbstractMediaFileServlet extends SlingSafeMethodsServlet {
       dispositionHeader.append("filename=\"").append(suffix).append('\"');
     }
     response.setHeader(HEADER_CONTENT_DISPOSITION, dispositionHeader.toString());
+  }
+
+  private void setSVGContentSecurityPolicy(@NotNull SlingHttpServletResponse response) {
+    response.setHeader(HEADER_CONTENT_SECURITY_POLICY, "sandbox");
   }
 
 }

--- a/src/main/java/io/wcm/handler/media/impl/MediaFileServlet.java
+++ b/src/main/java/io/wcm/handler/media/impl/MediaFileServlet.java
@@ -21,8 +21,14 @@ package io.wcm.handler.media.impl;
 
 import javax.servlet.Servlet;
 
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.HttpConstants;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import com.day.cq.commons.jcr.JcrConstants;
 
@@ -37,9 +43,34 @@ import com.day.cq.commons.jcr.JcrConstants;
     "sling.servlet.resourceTypes=" + JcrConstants.NT_RESOURCE,
     "sling.servlet.methods=" + HttpConstants.METHOD_GET
 })
+@Designate(ocd = MediaFileServlet.Config.class)
 public final class MediaFileServlet extends AbstractMediaFileServlet {
   private static final long serialVersionUID = 1L;
 
-  // inherits all functionality
+  private boolean svgContentSecurityPolicy;
+
+  @ObjectClassDefinition(
+      name = "wcm.io Media Handler Media File Servlet",
+      description = "Configures delivery of media file binaries.")
+  @interface Config {
+
+    @AttributeDefinition(
+        name = "SVG Content Security Policy",
+        description = "Apply XSS protection when serving SVG files by setting Content-Security-Policy to 'sandbox'.")
+    boolean svgContentSecurityPolicy() default true;
+
+  }
+
+  @Activate
+  private void activate(Config config) {
+    this.svgContentSecurityPolicy = config.svgContentSecurityPolicy();
+  }
+
+  @Override
+  protected void setSVGContentSecurityPolicy(@NotNull SlingHttpServletResponse response) {
+    if (this.svgContentSecurityPolicy) {
+      super.setSVGContentSecurityPolicy(response);
+    }
+  }
 
 }

--- a/src/main/java/io/wcm/handler/media/impl/MediaFileServletConstants.java
+++ b/src/main/java/io/wcm/handler/media/impl/MediaFileServletConstants.java
@@ -35,6 +35,11 @@ public final class MediaFileServletConstants {
   public static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
 
   /**
+   * Content disposition header
+   */
+  public static final String HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+
+  /**
    * Selector
    */
   public static final String SELECTOR = "media_file";

--- a/src/test/java/io/wcm/handler/media/impl/MediaFileServletTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaFileServletTest.java
@@ -20,6 +20,7 @@
 package io.wcm.handler.media.impl;
 
 import static io.wcm.handler.media.impl.MediaFileServletConstants.HEADER_CONTENT_DISPOSITION;
+import static io.wcm.handler.media.impl.MediaFileServletConstants.HEADER_CONTENT_SECURITY_POLICY;
 import static io.wcm.handler.media.impl.MediaFileServletConstants.SELECTOR_DOWNLOAD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -73,8 +74,8 @@ class MediaFileServletTest {
     assertEquals(ContentType.SVG, context.response().getContentType());
     assertEquals(EXPECTED_CONTENT_LENGTH_SVG, context.response().getOutput().length);
     assertEquals(EXPECTED_CONTENT_LENGTH_SVG, context.response().getContentLength());
-    // forced content disposition header for SVG to prevent stored XSS
-    assertEquals("attachment;", context.response().getHeader(HEADER_CONTENT_DISPOSITION));
+    // forced content security policy for SVG to prevent stored XSS
+    assertEquals("sandbox", context.response().getHeader(HEADER_CONTENT_SECURITY_POLICY));
   }
 
   @Test


### PR DESCRIPTION
as alternative to https://github.com/wcm-io/io.wcm.handler.media/pull/3, still allowing to embed SVG files via object tag, and not only via img tag

additionally, make this behavior configurable via OSGi configuration, as it may prevent special use cases e.g. SVGs animatd via JavaScript. by default, the feature is enabled.