### PR TITLE
Dynamic Media with OpenAPI with local assets: Introduce media invalid reason NOT_APPROVED

### DIFF
--- a/src/main/java/io/wcm/handler/media/MediaInvalidReason.java
+++ b/src/main/java/io/wcm/handler/media/MediaInvalidReason.java
@@ -36,7 +36,7 @@ public enum MediaInvalidReason {
 
   /**
    * Media reference is valid, but the media is not approved.
-   * This is only relevant for media served via Dynamic Media with OpenAPI.
+   * This is only relevant for local assets served via Dynamic Media with OpenAPI.
    */
   NOT_APPROVED,
 

--- a/src/main/java/io/wcm/handler/media/MediaInvalidReason.java
+++ b/src/main/java/io/wcm/handler/media/MediaInvalidReason.java
@@ -35,6 +35,12 @@ public enum MediaInvalidReason {
   MEDIA_REFERENCE_INVALID,
 
   /**
+   * Media reference is valid, but the media is not approved.
+   * This is only relevant for media served via Dynamic Media with OpenAPI.
+   */
+  NOT_APPROVED,
+
+  /**
    * No matching rendition: The media item exists, but no rendition matches for the requested media args.
    */
   NO_MATCHING_RENDITION,

--- a/src/main/java/io/wcm/handler/media/package-info.java
+++ b/src/main/java/io/wcm/handler/media/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Media Handler API.
  */
-@org.osgi.annotation.versioning.Version("2.0.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package io.wcm.handler.media;

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSource.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSource.java
@@ -91,7 +91,7 @@ public final class NextGenDynamicMediaMediaSource extends MediaSource {
   @AemObject(injectionStrategy = InjectionStrategy.OPTIONAL)
   private ComponentContext componentContext;
 
-  private static final Logger log = LoggerFactory.getLogger(NextGenDynamicMediaReference.class);
+  private static final Logger log = LoggerFactory.getLogger(NextGenDynamicMediaMediaSource.class);
 
   @Override
   public @NotNull String getId() {

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaReference.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaReference.java
@@ -19,9 +19,6 @@
  */
 package io.wcm.handler.mediasource.ngdm.impl;
 
-import static com.day.cq.dam.api.DamConstants.ASSET_STATUS_APPROVED;
-import static com.day.cq.dam.api.DamConstants.ASSET_STATUS_PROPERTY;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -139,11 +136,6 @@ public final class NextGenDynamicMediaReference {
     String uuid = asset.getID();
     if (StringUtils.isBlank(uuid)) {
       log.trace("Ignoring DAM asset without UUID: {}", asset.getPath());
-      return null;
-    }
-    String damStatus = asset.getMetadataValueFromJcr(ASSET_STATUS_PROPERTY);
-    if (!StringUtils.equals(damStatus, ASSET_STATUS_APPROVED)) {
-      log.trace("Ignoring DAM asset with {}='{}' (expected '{}')", ASSET_STATUS_PROPERTY, damStatus, ASSET_STATUS_APPROVED);
       return null;
     }
     String assetId = "urn:aaid:aem:" + uuid;

--- a/src/main/resources/i18n/de.json
+++ b/src/main/resources/i18n/de.json
@@ -4,6 +4,7 @@
     "invalidReason": {
       "MEDIA_REFERENCE_MISSING": "Keine Referenz",
       "MEDIA_REFERENCE_INVALID": "Ungültige Referenz",
+      "NOT_APPROVED": "Asset ist nicht genehmigt",
       "NO_MATCHING_RENDITION": "Passt nicht zum Medien-Format",
       "NOT_ENOUGH_MATCHING_RENDITIONS": "Nicht genügend zum Medien-Format passende Renditions",
       "INVALID_MEDIA_FORMAT": "Ungültiges Medien-Format"

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -4,6 +4,7 @@
     "invalidReason": {
       "MEDIA_REFERENCE_MISSING": "No reference",
       "MEDIA_REFERENCE_INVALID": "Invalid reference",
+      "NOT_APPROVED": "Asset not approved",
       "NO_MATCHING_RENDITION": "No matching media format",
       "NOT_ENOUGH_MATCHING_RENDITIONS": "Not enough renditions matching media formats",
       "INVALID_MEDIA_FORMAT": "Invalid media format"


### PR DESCRIPTION
Introduce media invalid reason "NOT_APPROVED" when assets are not approved for NGDM media source