### PR TITLE
62: Adds relative cropping support for Web-Optimized Image Delivery

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="2.1.2" date="not released">
+      <action type="add" dev="cnagel" issue="62">
+        Add relative cropping support for Web-Optimized Image Delivery
+      </action>
       <action type="add" dev="sseifert" issue="61">
         Dynamic Media with OpenAPI: Use static cropping (center cropping) if named smart cropping based on Image Profile define in AEM is not available.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
 
     <release version="2.2.0" date="not released">
       <action type="update" dev="cnagel" issue="62">
-        Web-Optimized Image Delivery: Use relative (percentage) parameters for cropping instead of abscolute parameters. This should create more reliable renditions esp. for original images in low resolution.
+        Web-Optimized Image Delivery: Use relative (percentage) parameters for cropping instead of absolute parameters. This should create more reliable renditions esp. for original images in low resolution.
         You can switch back to the old behavior by setting "Crop Option" to ABSOLUTE_PARAMETERS in the "wcm.io Media Handler Web-Optimized Image Delivery Support" OSGi configuration.
       </action>
       <action type="update" dev="sseifert" issue="61">

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/ParameterMap.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/ParameterMap.java
@@ -61,7 +61,8 @@ final class ParameterMap {
   }
 
   @NotNull
-  static Map<String, Object> build(@NotNull Asset asset, @NotNull WebOptimizedImageDeliveryParams params) {
+  static Map<String, Object> build(@NotNull Asset asset, @NotNull WebOptimizedImageDeliveryParams params,
+      @NotNull WebOptimizedImageDeliveryCropOption cropOption) {
     String path = asset.getPath();
     String seoName = FilenameUtils.getBaseName(asset.getName());
     String format = StringUtils.toRootLowerCase(FilenameUtils.getExtension(asset.getName()));
@@ -85,7 +86,7 @@ final class ParameterMap {
       map.put(PARAM_WIDTH, width.toString());
     }
     if (cropDimension != null) {
-      map.put(PARAM_CROP, createCroppingString(asset, cropDimension));
+      map.put(PARAM_CROP, createCroppingString(asset, cropDimension, cropOption));
     }
     if (rotation != null && rotation != 0) {
       map.put(PARAM_ROTATE, rotation.toString());
@@ -96,13 +97,15 @@ final class ParameterMap {
     return map;
   }
 
-  private static @NotNull String createCroppingString(
-          @NotNull Asset asset,
-          @NotNull CropDimension cropDimension) {
-    Dimension imageDimension = loadImageDimension(asset);
-    return imageDimension == null || imageDimension.getWidth() <= 0 || imageDimension.getHeight() <= 0
-            ? cropDimension.getCropStringWidthHeight()
-            : createRelativeCroppingString(imageDimension, cropDimension);
+  private static @NotNull String createCroppingString(@NotNull Asset asset, @NotNull CropDimension cropDimension,
+      @NotNull WebOptimizedImageDeliveryCropOption cropOption) {
+    if (cropOption == WebOptimizedImageDeliveryCropOption.RELATIVE_PARAMETERS) {
+      Dimension imageDimension = loadImageDimension(asset);
+      if (imageDimension != null && imageDimension.getWidth() > 0 && imageDimension.getHeight() > 0) {
+        return createRelativeCroppingString(imageDimension, cropDimension);
+      }
+    }
+    return cropDimension.getCropStringWidthHeight();
   }
 
   private static @Nullable Dimension loadImageDimension(@NotNull Asset asset) {

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/ParameterMap.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/ParameterMap.java
@@ -102,7 +102,7 @@ final class ParameterMap {
     if (cropOption == WebOptimizedImageDeliveryCropOption.RELATIVE_PARAMETERS) {
       Dimension imageDimension = loadImageDimension(asset);
       if (imageDimension != null && imageDimension.getWidth() > 0 && imageDimension.getHeight() > 0) {
-        return createRelativeCroppingString(imageDimension, cropDimension);
+        return RelativeCroppingString.createFromCropDimension(cropDimension, imageDimension);
       }
     }
     return cropDimension.getCropStringWidthHeight();
@@ -113,30 +113,6 @@ final class ParameterMap {
       return originalRendition == null
             ? null
             : AssetRendition.getDimension(originalRendition);
-  }
-
-  private static @NotNull String createRelativeCroppingString(
-          @NotNull Dimension imageDimension,
-          @NotNull CropDimension cropDimension) {
-    double x1 = cropDimension.getLeft();
-    double y1 = cropDimension.getTop();
-    double x2 = cropDimension.getRight();
-    double y2 = cropDimension.getBottom();
-    double left = x1 / imageDimension.getWidth();
-    double top = y1 / imageDimension.getHeight();
-    double width = (x2 - x1) / imageDimension.getWidth();
-    double height = (y2 - y1) / imageDimension.getHeight();
-    return createRelativeCroppingString(left, top, width, height);
-  }
-
-  static @NotNull String createRelativeCroppingString(double left, double top, double width, double height) {
-    return String.format("%.0fp,%.0fp,%.0fp,%.0fp",
-            toPercentage(left), toPercentage(top),
-            toPercentage(width), toPercentage(height));
-  }
-
-  private static double toPercentage(double fraction) {
-    return Math.round(fraction * 100);
   }
 
 }

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/RelativeCroppingString.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/RelativeCroppingString.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.dam.impl.weboptimized;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.wcm.handler.media.CropDimension;
+import io.wcm.handler.media.Dimension;
+
+/**
+ * Creates relative crop string with percentage values as required by the Web-Optimized Image Delivery API.
+ * It uses one fractional digit for the percentage values.
+ */
+final class RelativeCroppingString {
+
+  private static final NumberFormat DECIMAL_FORMAT = new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.US));
+
+  private RelativeCroppingString() {
+    // static methods only
+  }
+
+  static @NotNull String createFromCropDimension(
+      @NotNull CropDimension cropDimension, @NotNull Dimension imageDimension) {
+    double x1 = cropDimension.getLeft();
+    double y1 = cropDimension.getTop();
+    double left = x1 / imageDimension.getWidth();
+    double top = y1 / imageDimension.getHeight();
+    double width = (double)cropDimension.getWidth() / imageDimension.getWidth();
+    double height = (double)cropDimension.getHeight() / imageDimension.getHeight();
+    return create(left, top, width, height);
+  }
+
+  static @NotNull String create(double left, double top, double width, double height) {
+    return String.format("%sp,%sp,%sp,%sp",
+        toPercentage(left), toPercentage(top),
+        toPercentage(width), toPercentage(height));
+  }
+
+  private static String toPercentage(double fraction) {
+    return DECIMAL_FORMAT.format(Math.round(fraction * 1000d) / 10d);
+  }
+
+}

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/RelativeCroppingString.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/RelativeCroppingString.java
@@ -59,7 +59,10 @@ final class RelativeCroppingString {
   }
 
   private static String toPercentage(double fraction) {
-    return DECIMAL_FORMAT.format(Math.round(fraction * 1000d) / 10d);
+    double percentage = Math.round(fraction * 1000d) / 10d;
+    percentage = Math.max(0.0, percentage);
+    percentage = Math.min(100.0, percentage);
+    return DECIMAL_FORMAT.format(percentage);
   }
 
 }

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryCropOption.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryCropOption.java
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.dam.impl.weboptimized;
+
+/**
+ * Choose how to calculate/apply cropping parameter when using Web-Optimized image delivery.
+ */
+public enum WebOptimizedImageDeliveryCropOption {
+
+  /**
+   * Crop renditions using relative percentage values as parameters (e.g. crop=0.0p,5.0p,100.0p,80.0p),
+   * based on the original image dimensions.
+   */
+  RELATIVE_PARAMETERS,
+
+  /**
+   * Crop renditions using absolute pixel values as parameters (e.g. crop=0,10,200,100),
+   * based on the original image dimensions.
+   */
+  ABSOLUTE_PARAMETERS
+
+}

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryService.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryService.java
@@ -37,6 +37,12 @@ public interface WebOptimizedImageDeliveryService {
   boolean isEnabled();
 
   /**
+   * Cropping option to use.
+   * @return Cropping option
+   */
+  WebOptimizedImageDeliveryCropOption getCropOption();
+
+  /**
    * Get delivery URL for a rendition of an asset.
    * @param asset Asset
    * @param params Parameters

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryService.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryService.java
@@ -37,8 +37,8 @@ public interface WebOptimizedImageDeliveryService {
   boolean isEnabled();
 
   /**
-   * Cropping option to use.
-   * @return Cropping option
+   * Crop option to use.
+   * @return Crop option
    */
   WebOptimizedImageDeliveryCropOption getCropOption();
 

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryServiceImpl.java
@@ -55,16 +55,24 @@ public class WebOptimizedImageDeliveryServiceImpl implements WebOptimizedImageDe
         description = "Enable support for Web-Optimized Image Delivery (if available).")
     boolean enabled() default true;
 
+    @AttributeDefinition(
+        name = "Cropping Option",
+        description = "Use relative cropping parameters (e.g. crop=0.0p,5.0p,100.0p,80.0p) "
+            + "or absolute cropping paremters (e.g. crop=0,10,200,100), both based on the original image dimensions.")
+    WebOptimizedImageDeliveryCropOption cropOption() default WebOptimizedImageDeliveryCropOption.RELATIVE_PARAMETERS;
+
   }
 
   @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
   private AssetDelivery assetDelivery;
 
   private boolean enabled;
+  private WebOptimizedImageDeliveryCropOption cropOption;
 
   @Activate
   private void activate(Config config) {
     this.enabled = config.enabled();
+    this.cropOption = config.cropOption();
   }
 
   @Override
@@ -73,12 +81,17 @@ public class WebOptimizedImageDeliveryServiceImpl implements WebOptimizedImageDe
   }
 
   @Override
+  public WebOptimizedImageDeliveryCropOption getCropOption() {
+    return cropOption;
+  }
+
+  @Override
   public @Nullable String getDeliveryUrl(@NotNull Asset asset, @NotNull WebOptimizedImageDeliveryParams params) {
     if (!isEnabled()) {
       return null;
     }
     Resource resource = AdaptTo.notNull(asset, Resource.class);
-    Map<String, Object> parameterMap = ParameterMap.build(asset, params);
+    Map<String, Object> parameterMap = ParameterMap.build(asset, params, cropOption);
     return assetDelivery.getDeliveryURL(resource, parameterMap);
   }
 

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryServiceImpl.java
@@ -56,7 +56,7 @@ public class WebOptimizedImageDeliveryServiceImpl implements WebOptimizedImageDe
     boolean enabled() default true;
 
     @AttributeDefinition(
-        name = "Cropping Option",
+        name = "Crop Option",
         description = "Use relative cropping parameters (e.g. crop=0.0p,5.0p,100.0p,80.0p) "
             + "or absolute cropping paremters (e.g. crop=0,10,200,100), both based on the original image dimensions.")
     WebOptimizedImageDeliveryCropOption cropOption() default WebOptimizedImageDeliveryCropOption.RELATIVE_PARAMETERS;

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest.java
@@ -78,7 +78,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_JPEG_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25.0p%2C0.0p%2C50.0p%2C100.0p&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 
@@ -87,7 +87,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_JPEG_AutoCrop_ImageQuality() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=60&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25.0p%2C0.0p%2C50.0p%2C100.0p&preferwebp=true&quality=60&width=50",
         ContentType.JPEG, 0.6d);
   }
 
@@ -97,7 +97,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     context.create().assetRendition(asset, "square.jpg", 50, 50, ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25.0p%2C0.0p%2C50.0p%2C100.0p&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 
@@ -124,7 +124,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_GIF_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.gif", ContentType.GIF);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.gif?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.gif?c=25.0p%2C0.0p%2C50.0p%2C100.0p&preferwebp=true&quality=85&width=50",
         ContentType.GIF);
   }
 
@@ -151,7 +151,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_PNG_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.png", ContentType.PNG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.png?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.png?c=25.0p%2C0.0p%2C50.0p%2C100.0p&preferwebp=true&quality=85&width=50",
         ContentType.PNG);
   }
 
@@ -178,7 +178,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_TIFF_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.tif", ContentType.TIFF);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25.0p%2C0.0p%2C50.0p%2C100.0p&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest.java
@@ -78,7 +78,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_JPEG_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 
@@ -87,7 +87,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_JPEG_AutoCrop_ImageQuality() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=60&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=60&width=50",
         ContentType.JPEG, 0.6d);
   }
 
@@ -97,7 +97,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     context.create().assetRendition(asset, "square.jpg", 50, 50, ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 
@@ -124,7 +124,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_GIF_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.gif", ContentType.GIF);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.gif?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.gif?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
         ContentType.GIF);
   }
 
@@ -151,7 +151,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_PNG_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.png", ContentType.PNG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.png?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.png?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
         ContentType.PNG);
   }
 
@@ -178,7 +178,7 @@ class MediaHandlerImplImageFileTypesEnd2EndWebOptimizedImageDeliveryTest extends
   void testAsset_TIFF_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.tif", ContentType.TIFF);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25%2C0%2C50%2C50&preferwebp=true&quality=85&width=50",
+        "/adobe/dynamicmedia/deliver/" + getAssetId(asset) + "/sample.jpg?c=25p%2C0p%2C50p%2C100p&preferwebp=true&quality=85&width=50",
         ContentType.JPEG);
   }
 

--- a/src/test/java/io/wcm/handler/mediasource/dam/DamUriTemplateRenditionTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/DamUriTemplateRenditionTest.java
@@ -184,7 +184,7 @@ class DamUriTemplateRenditionTest {
         .build();
 
     assertUriTemplate(media.getRendition(), SCALE_WIDTH, 160, 120,
-        "/adobe/dynamicmedia/deliver/" + assetId + "/sample.jpg?c=8p%2C0p%2C83p%2C100p&preferwebp=true&quality=85&width={width}");
+        "/adobe/dynamicmedia/deliver/" + assetId + "/sample.jpg?c=8.3p%2C0.0p%2C83.3p%2C100.0p&preferwebp=true&quality=85&width={width}");
     assertUriTemplate(media.getRendition(), SCALE_HEIGHT, 160, 120,
         "/content/dam/folder1/sample.jpg/_jcr_content/renditions/original.image_file.0.{height}.16,0,176,120.file/sample.jpg");
   }

--- a/src/test/java/io/wcm/handler/mediasource/dam/DamUriTemplateRenditionTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/DamUriTemplateRenditionTest.java
@@ -184,7 +184,7 @@ class DamUriTemplateRenditionTest {
         .build();
 
     assertUriTemplate(media.getRendition(), SCALE_WIDTH, 160, 120,
-        "/adobe/dynamicmedia/deliver/" + assetId + "/sample.jpg?c=16%2C0%2C160%2C120&preferwebp=true&quality=85&width={width}");
+        "/adobe/dynamicmedia/deliver/" + assetId + "/sample.jpg?c=8p%2C0p%2C83p%2C100p&preferwebp=true&quality=85&width={width}");
     assertUriTemplate(media.getRendition(), SCALE_HEIGHT, 160, 120,
         "/content/dam/folder1/sample.jpg/_jcr_content/renditions/original.image_file.0.{height}.16,0,176,120.file/sample.jpg");
   }

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/weboptimized/RelativeCroppingStringTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/weboptimized/RelativeCroppingStringTest.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.mediasource.dam.impl.weboptimized;
+
+import static io.wcm.handler.mediasource.dam.impl.weboptimized.RelativeCroppingString.create;
+import static io.wcm.handler.mediasource.dam.impl.weboptimized.RelativeCroppingString.createFromCropDimension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.wcm.handler.media.CropDimension;
+import io.wcm.handler.media.Dimension;
+
+
+class RelativeCroppingStringTest {
+
+  @Test
+  void testCreate() {
+    assertEquals("0.0p,0.0p,100.0p,100.0p", create(0.0, 0.0, 1.0, 1.0));
+    assertEquals("15.0p,20.0p,55.0p,60.0p", create(0.15, 0.20, 0.55, 0.60));
+    assertEquals("15.1p,21.3p,49.5p,59.2p", create(0.1512, 0.2131, 0.4954, 0.5915));
+  }
+
+  @Test
+  void testCreateFromCropDimension() {
+    assertEquals("0.0p,0.0p,100.0p,100.0p", createFromCropDimension(new CropDimension(0, 0, 200, 100), new Dimension(200, 100)));
+    assertEquals("6.5p,55.0p,52.5p,67.0p", createFromCropDimension(new CropDimension(13, 55, 105, 67), new Dimension(200, 100)));
+  }
+
+}

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryServiceImplTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryServiceImplTest.java
@@ -25,6 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -36,9 +39,6 @@ import io.wcm.testing.mock.aem.dam.ngdm.MockAssetDelivery;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import io.wcm.wcm.commons.contenttype.ContentType;
-
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 @ExtendWith(AemContextExtension.class)
 class WebOptimizedImageDeliveryServiceImplTest {
@@ -97,11 +97,30 @@ class WebOptimizedImageDeliveryServiceImplTest {
     Asset asset = context.create().asset("/content/dam/Test_1.jpg", 1920, 604, ContentType.JPEG);
     String assetId = MockAssetDelivery.getAssetId(asset);
 
+    assertEquals(WebOptimizedImageDeliveryCropOption.RELATIVE_PARAMETERS, underTest.getCropOption());
+
     String cropping = URLEncoder.encode(createRelativeCroppingString(0.54, 0, 0.42, 1), StandardCharsets.UTF_8);
     assertEquals("/adobe/dynamicmedia/deliver/" + assetId + "/test-1.jpg?c=" + cropping + "&preferwebp=true&width=806",
             underTest.getDeliveryUrl(asset, new WebOptimizedImageDeliveryParams()
                     .width(806L)
                     .cropDimension(new CropDimension(1028, 0, 806, 604))));
+  }
+
+  @Test
+  void testGetDeliveryUrl_absoluteCropping() {
+    context.registerInjectActivateService(MockAssetDelivery.class);
+    WebOptimizedImageDeliveryService underTest = context.registerInjectActivateService(WebOptimizedImageDeliveryServiceImpl.class,
+        "cropOption", WebOptimizedImageDeliveryCropOption.ABSOLUTE_PARAMETERS.name());
+    Asset asset = context.create().asset("/content/dam/Test_1.jpg", 1920, 604, ContentType.JPEG);
+    String assetId = MockAssetDelivery.getAssetId(asset);
+
+    assertEquals(WebOptimizedImageDeliveryCropOption.ABSOLUTE_PARAMETERS, underTest.getCropOption());
+
+    String cropping = URLEncoder.encode("1028,0,806,604", StandardCharsets.UTF_8);
+    assertEquals("/adobe/dynamicmedia/deliver/" + assetId + "/test-1.jpg?c=" + cropping + "&preferwebp=true&width=806",
+        underTest.getDeliveryUrl(asset, new WebOptimizedImageDeliveryParams()
+            .width(806L)
+            .cropDimension(new CropDimension(1028, 0, 806, 604))));
   }
 
 }

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryServiceImplTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/weboptimized/WebOptimizedImageDeliveryServiceImplTest.java
@@ -19,7 +19,6 @@
  */
 package io.wcm.handler.mediasource.dam.impl.weboptimized;
 
-import static io.wcm.handler.mediasource.dam.impl.weboptimized.ParameterMap.createRelativeCroppingString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -84,7 +83,7 @@ class WebOptimizedImageDeliveryServiceImplTest {
     assertEquals("/adobe/dynamicmedia/deliver/" + assetId + "/test-1.jpg?preferwebp=true",
         underTest.getDeliveryUrl(asset, new WebOptimizedImageDeliveryParams()));
 
-    String cropping = URLEncoder.encode(createRelativeCroppingString(0, 0, 0.2, 0.4), StandardCharsets.UTF_8);
+    String cropping = URLEncoder.encode(RelativeCroppingString.create(0, 0, 0.2, 0.4), StandardCharsets.UTF_8);
     assertEquals("/adobe/dynamicmedia/deliver/" + assetId + "/test-1.jpg?c=" + cropping + "&preferwebp=true&r=90&width=10",
         underTest.getDeliveryUrl(asset, new WebOptimizedImageDeliveryParams()
             .width(10L).cropDimension(new CropDimension(0, 0, 2, 4)).rotation(90)));
@@ -99,11 +98,11 @@ class WebOptimizedImageDeliveryServiceImplTest {
 
     assertEquals(WebOptimizedImageDeliveryCropOption.RELATIVE_PARAMETERS, underTest.getCropOption());
 
-    String cropping = URLEncoder.encode(createRelativeCroppingString(0.54, 0, 0.42, 1), StandardCharsets.UTF_8);
+    String cropping = URLEncoder.encode(RelativeCroppingString.create(0.535, 0, 0.42, 1), StandardCharsets.UTF_8);
     assertEquals("/adobe/dynamicmedia/deliver/" + assetId + "/test-1.jpg?c=" + cropping + "&preferwebp=true&width=806",
-            underTest.getDeliveryUrl(asset, new WebOptimizedImageDeliveryParams()
-                    .width(806L)
-                    .cropDimension(new CropDimension(1028, 0, 806, 604))));
+        underTest.getDeliveryUrl(asset, new WebOptimizedImageDeliveryParams()
+            .width(806L)
+            .cropDimension(new CropDimension(1028, 0, 806, 604))));
   }
 
   @Test


### PR DESCRIPTION
* Use relative (percentage) parameters for cropping instead of absolute parameters. This should create more reliable renditions esp. for original images in low resolution.
* You can switch back to the old behavior by setting "Crop Option" to ABSOLUTE_PARAMETERS in the "wcm.io Media Handler Web-Optimized Image Delivery Support" OSGi configuration.

Fixes #62 