### PR TITLE
Dynamic Media with OpenAPI: Do not enable support for remote assets by default

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -31,6 +31,9 @@
         Dynamic Media with OpenAPI: Provide max. width/height in UriTemplate if source image dimension is available in metadata.
       </action>
       <action type="update" dev="sseifert">
+        Dynamic Media with OpenAPI: Do not enable support for remote assets by default. Since general availability the related configuration services not longer protected by a feature flag, so the feature has to be enabled explicitly via OSGi configuration.
+      </action>
+      <action type="update" dev="sseifert">
         Eliminate dependency to Commons Lang 2.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -30,7 +30,7 @@
       <action type="add" dev="sseifert" issue="61">
         Dynamic Media with OpenAPI: Provide max. width/height in UriTemplate if source image dimension is available in metadata.
       </action>
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="64">
         Dynamic Media with OpenAPI: Do not enable support for remote assets by default. Since general availability the related configuration services not longer protected by a feature flag, so the feature has to be enabled explicitly via OSGi configuration.
       </action>
       <action type="update" dev="sseifert">

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
@@ -50,7 +50,7 @@ public class NextGenDynamicMediaConfigServiceImpl implements NextGenDynamicMedia
     @AttributeDefinition(
         name = "Remote Assets",
         description = "Enable Dynamic Media with OpenAPI for remote assets.")
-    boolean enabledRemoteAssets() default true;
+    boolean enabledRemoteAssets() default false;
 
     @AttributeDefinition(
         name = "Local Assets",

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest.java
@@ -51,7 +51,8 @@ class MediaHandlerImplImageFileTypesEnd2EndNextGenDynamicMediaTest extends Media
     MockNextGenDynamicMediaConfig nextGenDynamicMediaConfig = context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class);
     nextGenDynamicMediaConfig.setEnabled(true);
     nextGenDynamicMediaConfig.setRepositoryId("repo1");
-    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
+    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class,
+        "enabledRemoteAssets", true);
     super.setUp();
   }
 

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModelTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModelTest.java
@@ -53,7 +53,8 @@ class NextGenDynamicMediaConfigModelTest {
 
   @Test
   void testWithConfigService() throws JSONException {
-    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
+    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class,
+        "enabledRemoteAssets", true);
 
     NextGenDynamicMediaConfigModel underTest = AdaptTo.notNull(context.request(), NextGenDynamicMediaConfigModel.class);
     assertTrue(underTest.isEnabled());

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSourceTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaMediaSourceTest.java
@@ -131,6 +131,7 @@ class NextGenDynamicMediaMediaSourceTest {
     nextGenDynamicMediaConfig.setEnabled(remoteAssets);
     nextGenDynamicMediaConfig.setRepositoryId("repo1");
     context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class,
+        "enabledRemoteAssets", true,
         "enabledLocalAssets", localAssets,
         "localAssetsRepositoryId", "localrepo1");
   }

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMedia_RemoteAssetWithMetadataTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMedia_RemoteAssetWithMetadataTest.java
@@ -75,7 +75,8 @@ class NextGenDynamicMedia_RemoteAssetWithMetadataTest {
     nextGenDynamicMediaConfig = context.registerInjectActivateService(MockNextGenDynamicMediaConfig.class);
     nextGenDynamicMediaConfig.setEnabled(true);
     nextGenDynamicMediaConfig.setRepositoryId("localhost:" + wmRuntimeInfo.getHttpPort());
-    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
+    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class,
+        "enabledRemoteAssets", true);
     context.registerInjectActivateService(NextGenDynamicMediaMetadataServiceImpl.class,
         "enabled", true);
 

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMedia_RemoteAssetWithoutMetadataTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMedia_RemoteAssetWithoutMetadataTest.java
@@ -64,7 +64,8 @@ class NextGenDynamicMedia_RemoteAssetWithoutMetadataTest {
     nextGenDynamicMediaConfig.setEnabled(true);
     nextGenDynamicMediaConfig.setRepositoryId("repo1");
 
-    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class);
+    context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class,
+        "enabledRemoteAssets", true);
 
     resource = context.create().resource(context.currentPage(), "test",
         MediaNameConstants.PN_MEDIA_REF, SAMPLE_REFERENCE);

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImplTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImplTest.java
@@ -41,6 +41,7 @@ class NextGenDynamicMediaConfigServiceImplTest {
   void testPropertiesDefaultConfig() {
     registerNextGenDynamicMediaConfig(context);
     NextGenDynamicMediaConfigService underTest = context.registerInjectActivateService(NextGenDynamicMediaConfigServiceImpl.class,
+        "enabledRemoteAssets", true,
         "enabledLocalAssets", true,
         "localAssetsRepositoryId", "localrepo1");
     assertTrue(underTest.isEnabledRemoteAssets());


### PR DESCRIPTION
Since general availability the related configuration services not longer protected by a feature flag, so the feature has to be enabled explicitly via OSGi configuration.