### PR TITLE
Dynamic Media: Control image quality for lossy output image for each media request

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -33,6 +33,10 @@
       <action type="update" dev="sseifert" issue="64">
         Dynamic Media with OpenAPI: Do not enable support for remote assets by default. Since general availability the related configuration services not longer protected by a feature flag, so the feature has to be enabled explicitly via OSGi configuration.
       </action>
+      <action type="update" dev="sseifert"><![CDATA[
+        Dynamic Media: Control image quality for lossy output image for each media request by appending "qlt" URL parameter, defaulting to the default image quality configured in the media handler configuration class.<br/>
+        <b>Breaking change:</b> You can disable this behavior by setting "Set Image Quality" to false in the "wcm.io Media Handler Dynamic Media Support" OSGi configuration. If disabled, the default image quality setting configured in Dynamic Media is used for all images.
+      ]]></action>
       <action type="update" dev="sseifert">
         Eliminate dependency to Commons Lang 2.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -33,7 +33,7 @@
       <action type="update" dev="sseifert" issue="64">
         Dynamic Media with OpenAPI: Do not enable support for remote assets by default. Since general availability the related configuration services not longer protected by a feature flag, so the feature has to be enabled explicitly via OSGi configuration.
       </action>
-      <action type="update" dev="sseifert"><![CDATA[
+      <action type="update" dev="sseifert" issue="65"><![CDATA[
         Dynamic Media: Control image quality for lossy output image for each media request by appending "qlt" URL parameter, defaulting to the default image quality configured in the media handler configuration class.<br/>
         <b>Breaking change:</b> You can disable this behavior by setting "Set Image Quality" to false in the "wcm.io Media Handler Dynamic Media Support" OSGi configuration. If disabled, the default image quality setting configured in Dynamic Media is used for all images.
       ]]></action>

--- a/src/main/java/io/wcm/handler/media/impl/ImageQualityPercentage.java
+++ b/src/main/java/io/wcm/handler/media/impl/ImageQualityPercentage.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package io.wcm.handler.mediasource.ngdm.impl;
+package io.wcm.handler.media.impl;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -25,7 +25,7 @@ import io.wcm.handler.media.MediaArgs;
 import io.wcm.handler.media.spi.MediaHandlerConfig;
 
 /**
- * Sanitizes SEO names for usage in context of Next Gen. Dynamic Media
+ * Gets image quality for current media request, with fallback to default quality.
  */
 public final class ImageQualityPercentage {
 

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
@@ -35,13 +35,13 @@ import com.day.cq.dam.scene7.api.constants.Scene7Constants;
 
 import io.wcm.handler.media.Dimension;
 import io.wcm.handler.media.MediaArgs;
+import io.wcm.handler.media.impl.ImageQualityPercentage;
 import io.wcm.handler.media.spi.MediaHandlerConfig;
 import io.wcm.handler.mediasource.dam.impl.dynamicmedia.DynamicMediaSupportService;
 import io.wcm.handler.mediasource.dam.impl.dynamicmedia.ImageProfile;
 import io.wcm.handler.mediasource.dam.impl.dynamicmedia.NamedDimension;
 import io.wcm.handler.mediasource.dam.impl.weboptimized.WebOptimizedImageDeliveryParams;
 import io.wcm.handler.mediasource.dam.impl.weboptimized.WebOptimizedImageDeliveryService;
-import io.wcm.handler.mediasource.ngdm.impl.ImageQualityPercentage;
 
 /**
  * Context objects require in DAM support implementation.

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
@@ -164,6 +164,14 @@ public final class DamContext implements Adaptable {
   }
 
   /**
+   * @return Whether to control image quality for lossy output formats for each media request via 'qlt' URL parameter
+   *         (instead of relying on default setting within Dynamic Media).
+   */
+  public boolean isDynamicMediaSetImageQuality() {
+    return dynamicMediaSupportService.isSetImageQuality();
+  }
+
+  /**
    * @return Dynamic media reply image size limit
    */
   public @NotNull Dimension getDynamicMediaImageSizeLimit() {

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportService.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportService.java
@@ -64,6 +64,12 @@ public interface DynamicMediaSupportService {
   Dimension getImageSizeLimit();
 
   /**
+   * @return Whether to control image quality for lossy output formats for each media request via 'qlt' URL parameter
+   *         (instead of relying on default setting within Dynamic Media).
+   */
+  boolean isSetImageQuality();
+
+  /**
    * Get image profile.
    * @param profilePath Full profile path
    * @return Profile or null if no profile found

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportServiceImpl.java
@@ -105,6 +105,11 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
         description = "The configured height value for 'Reply Image Size Limit'.")
     long imageSizeLimitHeight() default 2000;
 
+    @AttributeDefinition(
+        name = "Set Image Quality",
+        description = "Control image quality for lossy output formats for each media request via 'qlt' URL parameter (instead of relying on default setting within Dynamic Media).")
+    boolean setImageQuality() default false;
+
   }
 
   @Reference
@@ -118,6 +123,7 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
   private boolean disableAemFallback;
   private boolean validateSmartCropRenditionSizes;
   private Dimension imageSizeLimit;
+  private boolean setImageQuality;
 
   private static final String SERVICEUSER_SUBSERVICE = "dynamic-media-support";
   private static final Pattern DAM_PATH_PATTERN = Pattern.compile("^/content/dam(/.*)?$");
@@ -132,6 +138,7 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
     this.disableAemFallback = config.disableAemFallback();
     this.validateSmartCropRenditionSizes = config.validateSmartCropRenditionSizes();
     this.imageSizeLimit = new Dimension(config.imageSizeLimitWidth(), config.imageSizeLimitHeight());
+    this.setImageQuality = config.setImageQuality();
 
     if (this.enabled) {
       log.info("DynamicMediaSupport: enabled={}, capabilityEnabled={}, capabilityDetection={}, "
@@ -172,6 +179,11 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
   @Override
   public @NotNull Dimension getImageSizeLimit() {
     return this.imageSizeLimit;
+  }
+
+  @Override
+  public boolean isSetImageQuality() {
+    return setImageQuality;
   }
 
   @Override

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportServiceImpl.java
@@ -108,7 +108,7 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
     @AttributeDefinition(
         name = "Set Image Quality",
         description = "Control image quality for lossy output formats for each media request via 'qlt' URL parameter (instead of relying on default setting within Dynamic Media).")
-    boolean setImageQuality() default false;
+    boolean setImageQuality() default true;
 
   }
 

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaRendition.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaRendition.java
@@ -37,7 +37,7 @@ import io.wcm.handler.media.Rendition;
 import io.wcm.handler.media.UriTemplate;
 import io.wcm.handler.media.UriTemplateType;
 import io.wcm.handler.media.format.MediaFormat;
-import io.wcm.handler.mediasource.ngdm.impl.ImageQualityPercentage;
+import io.wcm.handler.media.impl.ImageQualityPercentage;
 import io.wcm.handler.mediasource.ngdm.impl.MediaArgsDimension;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaBinaryUrlBuilder;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaContext;

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaUriTemplate.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaUriTemplate.java
@@ -25,7 +25,7 @@ import io.wcm.handler.media.Dimension;
 import io.wcm.handler.media.MediaNameConstants;
 import io.wcm.handler.media.UriTemplate;
 import io.wcm.handler.media.UriTemplateType;
-import io.wcm.handler.mediasource.ngdm.impl.ImageQualityPercentage;
+import io.wcm.handler.media.impl.ImageQualityPercentage;
 import io.wcm.handler.mediasource.ngdm.impl.MediaArgsDimension;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaContext;
 import io.wcm.handler.mediasource.ngdm.impl.NextGenDynamicMediaImageDeliveryParams;

--- a/src/test/java/io/wcm/handler/media/impl/ImageQualityPercentageTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/ImageQualityPercentageTest.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package io.wcm.handler.mediasource.ngdm.impl;
+package io.wcm.handler.media.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplEnd2EndDynamicMediaSmartCropTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplEnd2EndDynamicMediaSmartCropTest.java
@@ -102,8 +102,8 @@ class MediaHandlerImplEnd2EndDynamicMediaSmartCropTest {
 
     List<Rendition> renditions = List.copyOf(media.getRenditions());
     assertEquals(2, renditions.size());
-    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=80&hei=60&fit=stretch", renditions.get(0).getUrl());
-    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=40&hei=30&fit=stretch", renditions.get(1).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=80&hei=60&fit=stretch&qlt=85", renditions.get(0).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=40&hei=30&fit=stretch&qlt=85", renditions.get(1).getUrl());
   }
 
   @Test
@@ -118,9 +118,9 @@ class MediaHandlerImplEnd2EndDynamicMediaSmartCropTest {
 
     List<Rendition> renditions = List.copyOf(media.getRenditions());
     assertEquals(3, renditions.size());
-    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=100&hei=75&fit=stretch", renditions.get(0).getUrl());
-    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=80&hei=60&fit=stretch", renditions.get(1).getUrl());
-    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=40&hei=30&fit=stretch", renditions.get(2).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=100&hei=75&fit=stretch&qlt=85", renditions.get(0).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=80&hei=60&fit=stretch&qlt=85", renditions.get(1).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=40&hei=30&fit=stretch&qlt=85", renditions.get(2).getUrl());
   }
 
   @Test
@@ -144,7 +144,7 @@ class MediaHandlerImplEnd2EndDynamicMediaSmartCropTest {
 
     List<Rendition> renditions = List.copyOf(media.getRenditions());
     assertEquals(1, renditions.size());
-    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=80&hei=60&fit=stretch", renditions.get(0).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=80&hei=60&fit=stretch&qlt=85", renditions.get(0).getUrl());
   }
 
   @Test
@@ -154,7 +154,7 @@ class MediaHandlerImplEnd2EndDynamicMediaSmartCropTest {
 
     List<Rendition> renditions = List.copyOf(media.getRenditions());
     assertEquals(1, renditions.size());
-    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A16-10?wid=120&hei=75&fit=stretch", renditions.get(0).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A16-10?wid=120&hei=75&fit=stretch&qlt=85", renditions.get(0).getUrl());
   }
 
   @Test

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest.java
@@ -49,7 +49,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_JPEG_Original() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia(asset, 100, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?wid=100&hei=50&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?wid=100&hei=50&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 
@@ -74,7 +74,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_JPEG_Rescale() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_Rescale(asset, 80, 40,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?wid=80&hei=40&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?wid=80&hei=40&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 
@@ -83,7 +83,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_JPEG_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?crop=25,0,50,50&wid=50&hei=50&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?crop=25,0,50,50&wid=50&hei=50&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 
@@ -92,7 +92,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_JPEG_AutoCrop_ImageQuality() {
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?crop=25,0,50,50&wid=50&hei=50&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?crop=25,0,50,50&wid=50&hei=50&fit=stretch&qlt=60",
         ContentType.JPEG, 0.6d);
   }
 
@@ -102,7 +102,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
     Asset asset = createSampleAsset("/filetype/sample.jpg", ContentType.JPEG);
     context.create().assetRendition(asset, "square.jpg", 50, 50, ContentType.JPEG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?crop=25,0,50,50&wid=50&hei=50&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.jpg?crop=25,0,50,50&wid=50&hei=50&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 
@@ -148,7 +148,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_GIF_Rescale() {
     Asset asset = createSampleAsset("/filetype/sample.gif", ContentType.GIF);
     buildAssertMedia_Rescale(asset, 80, 40,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.gif?wid=80&hei=40&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.gif?wid=80&hei=40&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 
@@ -157,7 +157,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_GIF_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.gif", ContentType.GIF);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.gif?crop=25,0,50,50&wid=50&hei=50&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.gif?crop=25,0,50,50&wid=50&hei=50&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 
@@ -235,7 +235,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_TIFF_Original() {
     Asset asset = createSampleAsset("/filetype/sample.tif", ContentType.TIFF);
     buildAssertMedia(asset, 100, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.tif?wid=100&hei=50&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.tif?wid=100&hei=50&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 
@@ -253,7 +253,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_TIFF_Rescale() {
     Asset asset = createSampleAsset("/filetype/sample.tif", ContentType.TIFF);
     buildAssertMedia_Rescale(asset, 80, 40,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.tif?wid=80&hei=40&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.tif?wid=80&hei=40&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 
@@ -262,7 +262,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_TIFF_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.tif", ContentType.TIFF);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.tif?crop=25,0,50,50&wid=50&hei=50&fit=stretch",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.tif?crop=25,0,50,50&wid=50&hei=50&fit=stretch&qlt=85",
         ContentType.JPEG);
   }
 

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaPathTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaPathTest.java
@@ -33,6 +33,7 @@ import org.apache.sling.api.resource.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.Constants;
 
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.DamConstants;
@@ -83,13 +84,26 @@ class DynamicMediaPathTest {
   @Test
   void testWidthHeight() {
     String result = DynamicMediaPath.buildImage(damContext, 30, 25);
+    assertEquals("/is/image/DummyFolder/test?wid=30&hei=25&fit=stretch&qlt=85", result);
+  }
+
+  @Test
+  void testWidthHeight_DisableSetImageQuality() {
+    // disable setImageQuality option
+    dynamicMediaSupportService = context.registerInjectActivateService(DynamicMediaSupportServiceImpl.class,
+        "setImageQuality", false,
+        Constants.SERVICE_RANKING, 1000);
+    damContext = new DamContext(asset, new MediaArgs(), mediaHandlerConfig,
+        dynamicMediaSupportService, webOptimizedImageDeliveryService, context.request());
+
+    String result = DynamicMediaPath.buildImage(damContext, 30, 25);
     assertEquals("/is/image/DummyFolder/test?wid=30&hei=25&fit=stretch", result);
   }
 
   @Test
   void testWidthHeight_ImplicitSmartCrop() {
     String result = DynamicMediaPath.buildImage(damContext, 30, 20);
-    assertEquals("/is/image/DummyFolder/test%3ACrop-1?wid=30&hei=20&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test%3ACrop-1?wid=30&hei=20&fit=stretch&qlt=85", result);
   }
 
   @Test
@@ -106,49 +120,49 @@ class DynamicMediaPathTest {
   @Test
   void testCrop() {
     String result = DynamicMediaPath.buildImage(damContext, 30, 20, new CropDimension(5, 2, 10, 8), null);
-    assertEquals("/is/image/DummyFolder/test?crop=5,2,10,8&wid=30&hei=20&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test?crop=5,2,10,8&wid=30&hei=20&fit=stretch&qlt=85", result);
   }
 
   @Test
   void testAutoCrop_SmartCrop() {
     String result = DynamicMediaPath.buildImage(damContext, 30, 20, new CropDimension(5, 2, 10, 8, true), null);
-    assertEquals("/is/image/DummyFolder/test%3ACrop-1?wid=30&hei=20&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test%3ACrop-1?wid=30&hei=20&fit=stretch&qlt=85", result);
   }
 
   @Test
   void testWidthHeight_MaxWidth() {
     String result = DynamicMediaPath.buildImage(damContext, 3000, 1500);
-    assertEquals("/is/image/DummyFolder/test?wid=2000&hei=1000&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test?wid=2000&hei=1000&fit=stretch&qlt=85", result);
   }
 
   @Test
   void testWidthHeight_MaxHeight() {
     String result = DynamicMediaPath.buildImage(damContext, 2500, 5000);
-    assertEquals("/is/image/DummyFolder/test?wid=1000&hei=2000&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test?wid=1000&hei=2000&fit=stretch&qlt=85", result);
   }
 
   @Test
   void testWidthHeight_MaxWidthHeight() {
     String result = DynamicMediaPath.buildImage(damContext, 6000, 8000);
-    assertEquals("/is/image/DummyFolder/test?wid=1500&hei=2000&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test?wid=1500&hei=2000&fit=stretch&qlt=85", result);
   }
 
   @Test
   void testRotate() {
     String result = DynamicMediaPath.buildImage(damContext, 30, 20, null, 180);
-    assertEquals("/is/image/DummyFolder/test?rotate=180&wid=30&hei=20&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test?rotate=180&wid=30&hei=20&fit=stretch&qlt=85", result);
   }
 
   @Test
   void testCropRotate() {
     String result = DynamicMediaPath.buildImage(damContext, 30, 20, new CropDimension(5, 2, 10, 8), 90);
-    assertEquals("/is/image/DummyFolder/test?crop=5,2,10,8&rotate=90&wid=30&hei=20&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test?crop=5,2,10,8&rotate=90&wid=30&hei=20&fit=stretch&qlt=85", result);
   }
 
   @Test
   void testAutoCropRotate_NoSmartCrop() {
     String result = DynamicMediaPath.buildImage(damContext, 30, 20, new CropDimension(5, 2, 10, 8, true), 90);
-    assertEquals("/is/image/DummyFolder/test?crop=5,2,10,8&rotate=90&wid=30&hei=20&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test?crop=5,2,10,8&rotate=90&wid=30&hei=20&fit=stretch&qlt=85", result);
   }
 
   @Test


### PR DESCRIPTION
Dynamic Media: Control image quality for lossy output image for each media request by appending "qlt" URL parameter, defaulting to the default image quality configured in the media handler configuration class.

**Breaking change:** You can disable this behavior by setting "Set Image Quality" to false in the "wcm.io Media Handler Dynamic Media Support" OSGi configuration. If disabled, the default image quality setting configured in Dynamic Media is used for all images.