### PR TITLE
GraniteUI validator: Use data-foundation-validation instead of data-validation HTML attribute

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -33,6 +33,9 @@
       <action type="fix" dev="sseifert" issue="72">
         Dynamic Media with OpenAPI: Respect Image Dimension from SVG asset metadata.
       </action>
+      <action type="fix" dev="sseifert">
+        GraniteUI validator: Use data-foundation-validation instead of data-validation HTML attribute, the latter is deprecated.
+      </action>
     </release>
 
     <release version="2.2.2" date="2024-09-16">

--- a/src/main/webapp/app-root/clientlibs/authoring/dialog/js/validation.js
+++ b/src/main/webapp/app-root/clientlibs/authoring/dialog/js/validation.js
@@ -42,7 +42,7 @@
 
   // predefined "responsiveWidths" pattern validator
   foundationValidator.register('foundation.validation.validator', {
-    selector: '[data-validation="wcmio.handler.media.responsiveWidths"]',
+    selector: '[data-foundation-validation="wcmio.handler.media.responsiveWidths"]',
     validate: function(el) {
       var value = getValue(el);
       var valid = value.length === 0 || pattern.responsiveWidths.test(value);


### PR DESCRIPTION
Use `data-foundation-validation` instead of `data-validation` HTML attribute, the latter is deprecated