### PR TITLE
Add documentation for graniteUI component properties

### DIFF
--- a/src/site/markdown/graniteui-components.md
+++ b/src/site/markdown/graniteui-components.md
@@ -25,6 +25,43 @@ Enhancements over AEM version:
 * The property `allowUpload` is set to `false` by default
 * The property `mimeTypes` is pre-initialized with mimetypes for GIF, JPEG and PNG images
 
+Properties
+- `name` (String) = {default value configured in media handler}\
+  The name that identifies the file upload location. E.g. ./file or ./image/file.
+- `fileNameParameter`**` (String) = {default value configured in media handler}\
+  The location for storing the name of the file. E.g. ./fileName or ./image/fileName
+- `fileReferenceParameter` (String) = {default value configured in media handler}\
+  The location for storing a DAM file reference. E.g. ./fileReference or ./image/fileReference
+- `namePrefix` (String) = "./"\
+  Prefix for all property names in the this component.
+  Can be used to store the properties in another resource by setting e.g. to "`./mySubNode/`".
+  Property value is ignored for properties name, fileNameParameter or fileReferenceParameter if those are set explicitly.
+- `mimeTypes` (String) multiple = ["image/gif","image/jpeg","image/png","image/tiff","image/svg+xml"]\
+  The browse and selection filter for file selection. E.g. [".png",".jpg"] or ["image/\*"].
+- `allowUpload` (Boolean) = `false`\
+  Indicates whether upload from local file system is allowed.
+- `fieldDescription` (String) = {media format information}\
+  When the field description is not set, it is set automatically with an information about the
+  supported media formats.
+- `rootPath` (String) = {root path from media handler config}\
+  The path of the root of the pathfield.
+- `fallbackRootPath` (String) = "/content/dam"\
+  The root path that is used as fallback when no root path could be detected dynamically,
+  e.g. because outside any site or within experience fragments.
+- `appendPath` (String) = {path appendix}\
+  Appendix path added to the (usually auto-detected) root path.
+- `mediaFormats` (String[]/String)\
+  List of media formats required by this component.
+  If not set the property value is looked up from component properties or policy.
+- `mediaFormatsMandatory` (String[]/String)\
+  List of mandatory media formats required by this component.
+  If not set the property value is looked up from component properties or policy.
+- `mediaCropAuto` (Boolean) = `false`\
+  Enables "auto-cropping" mode.
+  If not set the property value is looked up from component properties or policy.
+- `required` (Boolean) = `false`\
+  Property is mandatory.
+
 
 ### Media Handler-aware Path Field
 
@@ -47,6 +84,34 @@ This component extends the [wcm.io Granite UI components Path Field][wcmio-wcm-u
 * The property `rootPath` defaults to `/content/dam`
 * When the property `fieldDescription` is not set, it is set automatically with information about the expected media formats
 
+Properties
+- `name` (String) = {default value configured in media handler for media reference}\
+    The name that identifies the file upload location. E.g. ./file or ./image/file
+- `namePrefix` (String) = "./"\
+    Prefix for all property names in the this component.
+    Can be used to store the properties in another resource by setting e.g. to "./mySubNode/".
+    Property value is ignored for property name if this is set explicitly.
+    The path of the root of the pathfield.
+- `rootPath` (String) = {root path from media handler config}\
+- `fallbackRootPath` (String) = "/content/dam"\
+    The root path that is used as fallback when no root path could be detected dynamically,
+    e.g. because outside any site or within experience fragments.
+- `appendPath` (String) = {path appendix}\
+    Appendix path added to the (usually auto-detected) root path.
+- `fieldDescription` (String) = {media format information}\
+    When the field description is not set, it is set automatically with an information about the
+    supported media formats.
+- `mediaFormats` (String[]/String)\
+    List of media formats required by this component.
+    If not set the property value is looked up from component properties or policy.
+- `mediaFormatsMandatory` (String[]/String)\
+    List of mandatory media formats required by this component.
+    If not set the property value is looked up from component properties or policy.
+- `mediaCropAuto` (Boolean) = `false`\
+    Enables "auto-cropping" mode.
+    If not set the property value is looked up from component properties or policy.
+- `required` (Boolean) = `false`\
+    Property is mandatory.
 
 ### Media Formats Select Field
 
@@ -62,6 +127,9 @@ Multi-select field that allows to select one or multiple media formats.
 }
 ```
 
+Properties
+- `multiple` (Boolean) = `true`\
+  Media format select is multiple by default
 
 [component-properties]: component-properties.html
 [wcmio-wcm-ui-granite-pathfield]: https://wcm.io/wcm/ui/granite/components.html#Path_Field


### PR DESCRIPTION
Add documentation for graniteUI component properties. These are taken from the RST documentation in their JSP files.

@stefanseifert If the bullet list format does not fit, I can change them to tables.