### PR TITLE
Dynamic Media with Open API: Enable only when OSGi configuration for wcm.io Media Handler Dynamic Media with OpenAPI Support" is present

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="2.4.2" date="not release">
+      <action type="fix" dev="sseifert" issue="85">
+        Dynamic Media with Open API: Enable only when OSGi configuration for "wcm.io Media Handler Dynamic Media with OpenAPI Support" is present to avoid problems in AEM 6.5.
+      </action>
+    </release>
+
     <release version="2.4.0" date="2025-01-20">
       <action type="add" dev="mrozati" issue="77">
         MediaArgs accepts width options with density descriptors to generate srcset attribute with density descriptors like 2x instead of width descriptors like 800w.

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
-    <release version="2.4.2" date="not release">
+    <release version="2.4.2" date="not released">
       <action type="fix" dev="sseifert" issue="85">
         Dynamic Media with Open API: Enable only when OSGi configuration for "wcm.io Media Handler Dynamic Media with OpenAPI Support" is present to avoid problems in AEM 6.5.
       </action>

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModel.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModel.java
@@ -26,6 +26,7 @@ import javax.annotation.PostConstruct;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -48,7 +49,7 @@ public final class NextGenDynamicMediaConfigModel {
   private static final JsonMapper MAPPER = JsonMapper.builder().build();
   private static final Logger log = LoggerFactory.getLogger(NextGenDynamicMediaConfigModel.class);
 
-  @OSGiService
+  @OSGiService(injectionStrategy = InjectionStrategy.OPTIONAL)
   private NextGenDynamicMediaConfigService config;
 
   private boolean enabled;
@@ -57,9 +58,11 @@ public final class NextGenDynamicMediaConfigModel {
 
   @PostConstruct
   private void activate() {
-    enabled = config.isEnabledRemoteAssets();
-    assetSelectorsJsUrl = config.getAssetSelectorsJsUrl();
-    configJson = buildConfigJsonString(config);
+    if (config != null) {
+      enabled = config.isEnabledRemoteAssets();
+      assetSelectorsJsUrl = config.getAssetSelectorsJsUrl();
+      configJson = buildConfigJsonString(config);
+    }
   }
 
   private static String buildConfigJsonString(@NotNull NextGenDynamicMediaConfigService config) {

--- a/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/impl/NextGenDynamicMediaConfigServiceImpl.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -38,7 +39,7 @@ import com.adobe.cq.ui.wcm.commons.config.NextGenDynamicMediaConfig;
 /**
  * Wraps access to NextGenDynamicMediaConfig - which is deployed but not accessible on AEM 6.5.
  */
-@Component(service = NextGenDynamicMediaConfigService.class, immediate = true)
+@Component(service = NextGenDynamicMediaConfigService.class, immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE)
 @Designate(ocd = NextGenDynamicMediaConfigServiceImpl.Config.class)
 public class NextGenDynamicMediaConfigServiceImpl implements NextGenDynamicMediaConfigService {
 

--- a/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModelTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaConfigModelTest.java
@@ -20,6 +20,8 @@
 package io.wcm.handler.mediasource.ngdm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.json.JSONException;
@@ -61,6 +63,14 @@ class NextGenDynamicMediaConfigModelTest {
     assertEquals("/selector1", underTest.getAssetSelectorsJsUrl());
     JSONAssert.assertEquals("{repositoryId:'repo1',apiKey:'key1',env:'env1'}",
         underTest.getConfigJson(), true);
+  }
+
+  @Test
+  void testWithoutConfigService() {
+    NextGenDynamicMediaConfigModel underTest = AdaptTo.notNull(context.request(), NextGenDynamicMediaConfigModel.class);
+    assertFalse(underTest.isEnabled());
+    assertNull(underTest.getAssetSelectorsJsUrl());
+    assertNull(underTest.getConfigJson());
   }
 
 }


### PR DESCRIPTION
to avoid problems in AEM 6.5

Fixes #85 