### PR TITLE
DAM Media Source: Ignore min. width/height restrictions when trying to match SVG rendition

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -31,6 +31,9 @@
       <action type="fix" dev="sseifert" issue="88">
         Dynamic Media with Open API: Keep original width/height for SVG renditions.
       </action>
+      <action type="fix" dev="sseifert" issue="87">
+        DAM Media Source: Ignore min. width/height restrictions when trying to match SVG rendition.
+      </action>
     </release>
 
     <release version="2.4.0" date="2025-01-20">

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadata.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadata.java
@@ -252,7 +252,7 @@ class RenditionMetadata extends SlingAdaptable implements Comparable<RenditionMe
   }
 
   /**
-   * Checks if this rendition matches the given width/height/ration restrictions.
+   * Checks if this rendition matches the given width/height/ratio restrictions.
    * For vector images, min. width/height restrictions are ignored.
    * @param minWidth Min. width
    * @param minHeight Min. height
@@ -262,6 +262,7 @@ class RenditionMetadata extends SlingAdaptable implements Comparable<RenditionMe
    * @param ratio Ratio
    * @return true if matches
    */
+  @SuppressWarnings("java:S3776") // ignore complexity
   public boolean matches(long minWidth, long minHeight, long maxWidth, long maxHeight, long minWidthHeight, double ratio) {
     if (!isVectorImage()) {
       if (minWidthHeight > 0 && (getWidth() < minWidthHeight && getHeight() < minWidthHeight)) {

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadata.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadata.java
@@ -253,6 +253,7 @@ class RenditionMetadata extends SlingAdaptable implements Comparable<RenditionMe
 
   /**
    * Checks if this rendition matches the given width/height/ration restrictions.
+   * For vector images, min. width/height restrictions are ignored.
    * @param minWidth Min. width
    * @param minHeight Min. height
    * @param maxWidth Max. width
@@ -262,20 +263,22 @@ class RenditionMetadata extends SlingAdaptable implements Comparable<RenditionMe
    * @return true if matches
    */
   public boolean matches(long minWidth, long minHeight, long maxWidth, long maxHeight, long minWidthHeight, double ratio) {
-    if (minWidthHeight > 0 && (getWidth() < minWidthHeight && getHeight() < minWidthHeight)) {
-      return false;
-    }
-    if (minWidth > 0 && getWidth() < minWidth) {
-      return false;
-    }
-    if (minHeight > 0 && getHeight() < minHeight) {
-      return false;
-    }
-    if (maxWidth > 0 && getWidth() > maxWidth) {
-      return false;
-    }
-    if (maxHeight > 0 && getHeight() > maxHeight) {
-      return false;
+    if (!isVectorImage()) {
+      if (minWidthHeight > 0 && (getWidth() < minWidthHeight && getHeight() < minWidthHeight)) {
+        return false;
+      }
+      if (minWidth > 0 && getWidth() < minWidth) {
+        return false;
+      }
+      if (minHeight > 0 && getHeight() < minHeight) {
+        return false;
+      }
+      if (maxWidth > 0 && getWidth() > maxWidth) {
+        return false;
+      }
+      if (maxHeight > 0 && getHeight() > maxHeight) {
+        return false;
+      }
     }
     if (ratio > 0) {
       double renditionRatio = Ratio.get(getWidth(), getHeight());

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadataTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadataTest.java
@@ -57,16 +57,9 @@ class RenditionMetadataTest extends AbstractDamTest {
     Asset asset = media.getAsset().adaptTo(Asset.class);
 
     originalRendition = new RenditionMetadata(asset.getRendition("original"));
-    assertNotNull(originalRendition);
-
     originalRenditionCopy = new RenditionMetadata(asset.getRendition("cq5dam.thumbnail.215.102.jpg"));
-    assertNotNull(originalRenditionCopy);
-
     smallestRendition = new RenditionMetadata(asset.getRendition("cq5dam.web.450.213.jpg"));
-    assertNotNull(smallestRendition);
-
     biggestRendition = new RenditionMetadata(asset.getRendition("cq5dam.web.960.455.jpg"));
-    assertNotNull(biggestRendition);
   }
 
   /**
@@ -148,7 +141,6 @@ class RenditionMetadataTest extends AbstractDamTest {
     Asset asset = context.create().asset("/content/dam/sample.svg", "/filetype/sample.svg", ContentType.SVG);
 
     originalRendition = new RenditionMetadata(asset.getRendition("original"));
-    assertNotNull(originalRendition);
 
     assertTrue(originalRendition.matches(400, 100, 400, 100, 0, 0d));
     assertFalse(originalRendition.matches(400, 100, 400, 100, 0, 4d));

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadataTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/RenditionMetadataTest.java
@@ -38,6 +38,7 @@ import com.day.image.Layer;
 
 import io.wcm.handler.media.Media;
 import io.wcm.handler.mediasource.dam.AbstractDamTest;
+import io.wcm.wcm.commons.contenttype.ContentType;
 
 /**
  * Tests the {@link RenditionMetadata}, especially the compareTo method
@@ -140,6 +141,21 @@ class RenditionMetadataTest extends AbstractDamTest {
 
     assertTrue(smallestRendition.matches(0, 0, 0, 0, 0, 2.11d));
     assertFalse(smallestRendition.matches(0, 0, 0, 0, 0, 2.2d));
+  }
+
+  @Test
+  void testMatchesSpec_SVG() {
+    Asset asset = context.create().asset("/content/dam/sample.svg", "/filetype/sample.svg", ContentType.SVG);
+
+    originalRendition = new RenditionMetadata(asset.getRendition("original"));
+    assertNotNull(originalRendition);
+
+    assertTrue(originalRendition.matches(400, 100, 400, 100, 0, 0d));
+    assertFalse(originalRendition.matches(400, 100, 400, 100, 0, 4d));
+
+    assertTrue(originalRendition.matches(200, 100, 200, 100, 0, 2d)); // allow SVG upscaling
+    assertTrue(originalRendition.matches(100, 50, 100, 50, 0, 2d));
+    assertTrue(originalRendition.matches(50, 25, 50, 25, 0, 2d));
   }
 
   @Test


### PR DESCRIPTION
* Unlike raster image renditions, SVG renditions can be down- and upscaled freely
* So when trying to check for matching renditions in the candidate list, check only ratio match for SVG, but ignore min. width/height restrictions