### PR TITLE
Dynamic Media with Open API: Keep original width/height for SVG renditions

### DIFF
--- a/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaRendition.java
+++ b/src/main/java/io/wcm/handler/mediasource/ngdm/NextGenDynamicMediaRendition.java
@@ -101,8 +101,14 @@ final class NextGenDynamicMediaRendition implements Rendition {
       this.url = buildBinaryUrl();
     }
     else if (isVectorImage()) {
-      // calculate width/height for rendition metadata
-      calculateWidthHeight();
+      if (this.originalDimension != null) {
+        // set original width/height for vector image
+        this.width = this.originalDimension.getWidth();
+        this.height = this.originalDimension.getHeight();
+      }
+      else {
+        calculateWidthHeight();
+      }
       // deliver as binary
       this.url = buildBinaryUrl();
     }


### PR DESCRIPTION
* When rendering SVG renditions via Dynamic Media with Open API, keep original width/height of SVG rendition
* Do not create "virtual" SVG renditions with requested width/height, as SVG can be freely scaled down/up anyway