### PR TITLE
Dynamic Media: Make response image format (fmt) configurable via OSGi  for images with and without alpha channel

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="2.5.0" date="not released">
-      <action type="add" dev="sseifert"><![CDATA[
+      <action type="add" dev="sseifert" issue="103"><![CDATA[
         Dynamic Media: Make response image format (<code>fmt</code> URL parameter) configurable via OSGi for images with and without alpha channel.<br/>
         <b>Breaking change:</b> The default format for images with alpha channel has changed from "png-alpha" to "webp-alpha". Your can restore the previous behavior by setting <code>defaultFmtAlpha</code> to "png-alpha" via OSGi configuration.
       ]]></action>

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,11 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
-    <release version="2.4.4" date="not released">
+    <release version="2.5.0" date="not released">
+      <action type="add" dev="sseifert"><![CDATA[
+        Dynamic Media: Make response image format (<code>fmt</code> URL parameter) configurable via OSGi for images with and without alpha channel.<br/>
+        <b>Breaking change:</b> The default format for images with alpha channel has changed from "png-alpha" to "webp-alpha". Your can restore the previous behavior by setting <code>defaultFmtAlpha</code> to "png-alpha" via OSGi configuration.
+      ]]></action>
       <action type="update" dev="sseifert" issue="101">
         global.jsp: Get rid of deprecated Granite XSS API.
       </action>

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/DamContext.java
@@ -172,6 +172,23 @@ public final class DamContext implements Adaptable {
   }
 
   /**
+   * @return Default response image format. If empty, the default setting that is configured on the Dynamic Media server
+   *         environment is used. Accepts the same values as the 'fmt' parameter from the Dynamic Media Image Service
+   *         API.
+   */
+  public @NotNull String getDynamicMediaDefaultFmt() {
+    return dynamicMediaSupportService.getDefaultFmt();
+  }
+
+  /**
+   * @return Default response image format for source images that may have an alpha channel (e.g. for PNG). Accepts the
+   *         same values as the 'fmt' parameter from the Dynamic Media Image Service API.
+   */
+  public @NotNull String getDynamicMediaDefaultFmtAlpha() {
+    return dynamicMediaSupportService.getDefaultFmtAlpha();
+  }
+
+  /**
    * @return Dynamic media reply image size limit
    */
   public @NotNull Dimension getDynamicMediaImageSizeLimit() {

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportService.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportService.java
@@ -70,6 +70,21 @@ public interface DynamicMediaSupportService {
   boolean isSetImageQuality();
 
   /**
+   * @return Default response image format. If empty, the default setting that is configured on the Dynamic Media server
+   *         environment is used. Accepts the same values as the 'fmt' parameter from the Dynamic Media Image Service
+   *         API.
+   */
+  @NotNull
+  String getDefaultFmt();
+
+  /**
+   * @return Default response image format for source images that may have an alpha channel (e.g. for PNG). Accepts the
+   *         same values as the 'fmt' parameter from the Dynamic Media Image Service API.
+   */
+  @NotNull
+  String getDefaultFmtAlpha();
+
+  /**
    * Get image profile.
    * @param profilePath Full profile path
    * @return Profile or null if no profile found

--- a/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportServiceImpl.java
+++ b/src/main/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaSupportServiceImpl.java
@@ -110,6 +110,19 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
         description = "Control image quality for lossy output formats for each media request via 'qlt' URL parameter (instead of relying on default setting within Dynamic Media).")
     boolean setImageQuality() default true;
 
+    @AttributeDefinition(
+        name = "Default Format",
+        description = "Default response image format. "
+            + "If empty, the default setting that is configured on the Dynamic Media server environment is used. "
+            + "Accepts the same values as the 'fmt' parameter from the Dynamic Media Image Service API.")
+    String defaultFmt() default "";
+
+    @AttributeDefinition(
+        name = "Default Format Alpha Channel",
+        description = "Default response image format for source images that may have an alpha channel (e.g. for PNG). "
+            + "Accepts the same values as the 'fmt' parameter from the Dynamic Media Image Service API.")
+    String defaultFmtAlpha() default "webp-alpha";
+
   }
 
   @Reference
@@ -124,6 +137,8 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
   private boolean validateSmartCropRenditionSizes;
   private Dimension imageSizeLimit;
   private boolean setImageQuality;
+  private String defaultFmt;
+  private String defaultFmtAlpha;
 
   private static final String SERVICEUSER_SUBSERVICE = "dynamic-media-support";
   private static final Pattern DAM_PATH_PATTERN = Pattern.compile("^/content/dam(/.*)?$");
@@ -139,6 +154,8 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
     this.validateSmartCropRenditionSizes = config.validateSmartCropRenditionSizes();
     this.imageSizeLimit = new Dimension(config.imageSizeLimitWidth(), config.imageSizeLimitHeight());
     this.setImageQuality = config.setImageQuality();
+    this.defaultFmt = StringUtils.trim(config.defaultFmt());
+    this.defaultFmtAlpha = StringUtils.trim(config.defaultFmtAlpha());
 
     if (this.enabled) {
       log.info("DynamicMediaSupport: enabled={}, capabilityEnabled={}, capabilityDetection={}, "
@@ -183,7 +200,18 @@ public class DynamicMediaSupportServiceImpl implements DynamicMediaSupportServic
 
   @Override
   public boolean isSetImageQuality() {
-    return setImageQuality;
+    return this.setImageQuality;
+  }
+
+
+  @Override
+  public @NotNull String getDefaultFmt() {
+    return this.defaultFmt;
+  }
+
+  @Override
+  public @NotNull String getDefaultFmtAlpha() {
+    return this.defaultFmtAlpha;
   }
 
   @Override

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplEnd2EndDynamicMediaSmartCropTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplEnd2EndDynamicMediaSmartCropTest.java
@@ -168,7 +168,7 @@ class MediaHandlerImplEnd2EndDynamicMediaSmartCropTest {
 
     List<Rendition> renditions = List.copyOf(media.getRenditions());
     assertEquals(1, renditions.size());
-    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=133&hei=100&fit=stretch&fmt=png-alpha", renditions.get(0).getUrl());
+    assertEquals("https://dummy.scene7.com/is/image/DummyFolder/test%3A4-3?wid=133&hei=100&fit=stretch&fmt=webp-alpha", renditions.get(0).getUrl());
   }
 
 

--- a/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest.java
+++ b/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest.java
@@ -187,7 +187,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_PNG_Original() {
     Asset asset = createSampleAsset("/filetype/sample.png", ContentType.PNG);
     buildAssertMedia(asset, 100, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.png?wid=100&hei=50&fit=stretch&fmt=png-alpha",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.png?wid=100&hei=50&fit=stretch&fmt=webp-alpha",
         ContentType.PNG);
   }
 
@@ -196,7 +196,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_PNG_Rescale() {
     Asset asset = createSampleAsset("/filetype/sample.png", ContentType.PNG);
     buildAssertMedia_Rescale(asset, 80, 40,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.png?wid=80&hei=40&fit=stretch&fmt=png-alpha",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.png?wid=80&hei=40&fit=stretch&fmt=webp-alpha",
         ContentType.PNG);
   }
 
@@ -205,7 +205,7 @@ class MediaHandlerImplImageFileTypesEnd2EndDynamicMediaTest extends MediaHandler
   void testAsset_PNG_AutoCrop() {
     Asset asset = createSampleAsset("/filetype/sample.png", ContentType.PNG);
     buildAssertMedia_AutoCrop(asset, 50, 50,
-        "https://dummy.scene7.com/is/image/DummyFolder/sample.png?crop=25,0,50,50&wid=50&hei=50&fit=stretch&fmt=png-alpha",
+        "https://dummy.scene7.com/is/image/DummyFolder/sample.png?crop=25,0,50,50&wid=50&hei=50&fit=stretch&fmt=webp-alpha",
         ContentType.PNG);
   }
 

--- a/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaPathTest.java
+++ b/src/test/java/io/wcm/handler/mediasource/dam/impl/dynamicmedia/DynamicMediaPathTest.java
@@ -88,16 +88,18 @@ class DynamicMediaPathTest {
   }
 
   @Test
-  void testWidthHeight_DisableSetImageQuality() {
+  void testWidthHeight_DisableSetImageQuality_DefaultFmt() {
     // disable setImageQuality option
     dynamicMediaSupportService = context.registerInjectActivateService(DynamicMediaSupportServiceImpl.class,
         "setImageQuality", false,
+        "defaultFmt", "avif",
+        "defaultFmtAlpha", "avif-alpha",
         Constants.SERVICE_RANKING, 1000);
     damContext = new DamContext(asset, new MediaArgs(), mediaHandlerConfig,
         dynamicMediaSupportService, webOptimizedImageDeliveryService, context.request());
 
     String result = DynamicMediaPath.buildImage(damContext, 30, 25);
-    assertEquals("/is/image/DummyFolder/test?wid=30&hei=25&fit=stretch", result);
+    assertEquals("/is/image/DummyFolder/test?wid=30&hei=25&fit=stretch&fmt=avif", result);
   }
 
   @Test
@@ -196,7 +198,7 @@ class DynamicMediaPathTest {
         dynamicMediaSupportService, webOptimizedImageDeliveryService, context.request());
 
     String result = DynamicMediaPath.buildImage(damContext, 30, 20, new CropDimension(5, 2, 10, 8), null);
-    assertEquals("/is/image/DummyFolder/test?crop=5,2,10,8&wid=30&hei=20&fit=stretch&fmt=png-alpha", result);
+    assertEquals("/is/image/DummyFolder/test?crop=5,2,10,8&wid=30&hei=20&fit=stretch&fmt=webp-alpha", result);
   }
 
 }


### PR DESCRIPTION
**Breaking change:** The default format for images with alpha channel has changed from "png-alpha" to "webp-alpha". Your can restore the previous behavior by setting `defaultFmtAlpha` to "png-alpha" via OSGi configuration.

This PR introduces two new OSGi parameters for the service wcm.io Media Handler Dynamic Media Support (`io.wcm.handler.mediasource.dam.impl.dynamicmedia.DynamicMediaSupportServiceImpl`):
* `defaultFmt`
  * defaults to empty string ""
  * Default response image format. If empty, the default setting that is configured on the Dynamic Media server environment is used. Accepts the same values as the [`fmt` parameter from the Dynamic Media Image Service API](https://experienceleague.adobe.com/en/docs/dynamic-media-developer-resources/image-serving-api/image-serving-api/http-protocol-reference/command-reference/r-is-http-fmt).
* `defaultFmtAlpha` 
  *  defaults to "webp-alpha"
  * Default response image format for source images that may have an alpha channel (e.g. for PNG). Accepts the same values as the [`fmt` parameter from the Dynamic Media Image Service API](https://experienceleague.adobe.com/en/docs/dynamic-media-developer-resources/image-serving-api/image-serving-api/http-protocol-reference/command-reference/r-is-http-fmt).


Fixes #99 