### PR TITLE
MediaFileServlet: Detect ExternalizableInputStream for original rendition delivery

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -29,6 +29,9 @@
         Dynamic Media: Make response image format (<code>fmt</code> URL parameter) configurable via OSGi for images with and without alpha channel.<br/>
         <b>Breaking change:</b> The default format for images with alpha channel has changed from "png-alpha" to "webp-alpha". Your can restore the previous behavior by setting <code>defaultFmtAlpha</code> to "png-alpha" via OSGi configuration.
       ]]></action>
+      <action type="update" dev="sseifert">
+        MediaFileServlet: Detect if original rendition can be services via an external cloud URL (ExternalizableInputStream), and redirect to that if that is the case.
+      </action>
       <action type="update" dev="sseifert" issue="101">
         global.jsp: Get rid of deprecated Granite XSS API.
       </action>

--- a/src/main/java/io/wcm/handler/media/impl/BinaryDataResponse.java
+++ b/src/main/java/io/wcm/handler/media/impl/BinaryDataResponse.java
@@ -1,0 +1,59 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2025 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.media.impl;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Response object for getting binary data or redirect URL for {@link AbstractMediaFileServlet}.
+ */
+final class BinaryDataResponse {
+
+  private final byte[] binaryData;
+  private final String redirectUrl;
+
+  private BinaryDataResponse(byte @Nullable [] binaryData, @Nullable String redirectUrl) {
+    this.binaryData = binaryData;
+    this.redirectUrl = redirectUrl;
+  }
+
+  byte @Nullable [] getBinaryData() {
+    return this.binaryData;
+  }
+
+  @Nullable
+  String getRedirectUrl() {
+    return this.redirectUrl;
+  }
+
+  static BinaryDataResponse binaryData(byte @NotNull [] binaryData) {
+    return new BinaryDataResponse(binaryData, null);
+  }
+
+  static BinaryDataResponse redirectUrl(@NotNull String redirectUrl) {
+    return new BinaryDataResponse(null, redirectUrl);
+  }
+
+  static BinaryDataResponse invalid() {
+    return new BinaryDataResponse(null, null);
+  }
+
+}

--- a/src/main/java/io/wcm/handler/media/impl/ImageFileServlet.java
+++ b/src/main/java/io/wcm/handler/media/impl/ImageFileServlet.java
@@ -68,7 +68,7 @@ public final class ImageFileServlet extends AbstractMediaFileServlet {
 
   @Override
   @SuppressWarnings("java:S3776") // ignore complexity
-  protected byte @Nullable [] getBinaryData(@NotNull Resource resource, @NotNull SlingHttpServletRequest request) throws IOException {
+  protected @NotNull BinaryDataResponse getBinaryData(@NotNull Resource resource, @NotNull SlingHttpServletRequest request) throws IOException {
     // get media app config
     MediaHandlerConfig config = AdaptTo.notNull(request, MediaHandlerConfig.class);
 
@@ -82,12 +82,12 @@ public final class ImageFileServlet extends AbstractMediaFileServlet {
 
     // ensure valid image size
     if (width < 0 || height < 0 || (width == 0 && height == 0)) {
-      return null;
+      return BinaryDataResponse.invalid();
     }
 
     Layer layer = ResourceLayerUtil.toLayer(resource, assetStore);
     if (layer == null) {
-      return null;
+      return BinaryDataResponse.invalid();
     }
 
     // if only width or only height is given - derive other value from ratio
@@ -142,7 +142,7 @@ public final class ImageFileServlet extends AbstractMediaFileServlet {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     layer.write(contentType, layerQuality, bos);
     bos.flush();
-    return bos.toByteArray();
+    return BinaryDataResponse.binaryData(bos.toByteArray());
   }
 
   @Override


### PR DESCRIPTION
Detection based on Sling API: https://sling.apache.org/apidocs/sling13/org/apache/sling/api/resource/external/ExternalizableInputStream.html